### PR TITLE
Use FQCN for Str classes - Laravel 6.x

### DIFF
--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 
 class LaraBug
 {
@@ -187,7 +188,7 @@ class LaraBug
      */
     private function createExceptionString(array $data)
     {
-        return 'larabug.' . str_slug($data['host'] . '_' . $data['method'] . '_' . $data['exception'] . '_' . $data['line'] . '_' . $data['file'] . '_' . $data['class']);
+        return 'larabug.' . Str::slug($data['host'] . '_' . $data['method'] . '_' . $data['exception'] . '_' . $data['line'] . '_' . $data['file'] . '_' . $data['class']);
     }
 
     /**


### PR DESCRIPTION
String & Array helpers [are gone in Laravel 6.x](https://laravel.com/docs/6.x/upgrade#helpers), just use the FQCN for those functions ..