### PR TITLE
Log Exceptions by default only on Production-environment

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -18,8 +18,7 @@ return [
      * Environments where LaraBug should report
      */
     'environments' => [
-        'production',
-        'local'
+        'production'
     ],
 
     /*


### PR DESCRIPTION
There is no need to log exceptions on/via local environment by default-configuration, by default only on production.