### PR TITLE
Set default values for login/project key

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -6,13 +6,13 @@ return [
      * This is your authorization key which you get from your profile.
      * @ http://www.larabug.com
      */
-    'login_key' => env('LB_KEY'),
+    'login_key' => env('LB_KEY', 'LB_KEY'),
 
     /*
      * This is your project key which you receive when creating a project
      * @ http://www.larabug.com/projects
      */
-    'project_key' => env('LB_PROJECT_KEY'),
+    'project_key' => env('LB_PROJECT_KEY', 'LB_PROJECT_KEY'),
 
     /*
      * Environments where LaraBug should report

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -45,8 +45,8 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->singleton('larabug', function ($app) {
             return new LaraBug(new \LaraBug\Http\Client(
-                config('larabug.login_key'),
-                config('larabug.project_key')
+                config('larabug.login_key', 'login_key'),
+                config('larabug.project_key', 'project_key')
             ));
         });
 


### PR DESCRIPTION
The `LaraBug\Http\Client` expects a `string` login/project key, but if the user didn't set up the env-values correctly, this will create an exception.

This pull-request will fix that by setting default values in the config and the service provider (since we can't be sure users will re-apply the config-file every time)