### PR TITLE
guzzle 6.0.2+ for lowest-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,15 @@ matrix:
   fast_finish: true
   include:
     - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4
+      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4
       env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-stable'
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "require": {
     "php": ">=7.1.3",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "^6.0.2",
     "illuminate/support": "5.8.*|^6.0|^7.0"
   },
   "require-dev": {


### PR DESCRIPTION
The fuction `createWithMiddleware` was introducted with Guzzle 6.0.2, so, thats the absolute minium for this package.

https://github.com/guzzle/guzzle/commit/a1c986a4bc470a0959a2b1d5bc3e5b945a72dcb5