### PR TITLE
Adding `toLarabug` for AuthUser Model for overwriting more/less info about User

### DIFF
--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -2,12 +2,10 @@
 
 namespace LaraBug;
 
-use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use LaraBug\Http\Client;
 use Throwable;
@@ -286,10 +284,34 @@ class LaraBug
 
     /**
      * @param $exception
+     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\ResponseInterface|null
      */
     private function logError($exception)
     {
-        return $this->client->report($exception);
+        return $this->client->report([
+            'exception' => $exception,
+            'user' => $this->getUser(),
+        ]);
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getUser()
+    {
+        if (function_exists('auth') && auth()->check()) {
+            $user = auth()->user();
+
+            if (method_exists($user, 'toLarabug')) {
+                return $user->toLarabug();
+            }
+
+            if (method_exists($user, 'toArray')) {
+                return $user->toArray();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use Illuminate\Foundation\Auth\User as AuthUser;
+use LaraBug\LaraBug;
+use LaraBug\Tests\Mocks\LaraBugClient;
+
+class UserTest extends TestCase
+{
+    /** @var Mocks\LaraBugClient */
+    protected $client;
+
+    /** @var LaraBug */
+    protected $larabug;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->larabug = new LaraBug($this->client = new LaraBugClient(
+            'login_key', 'project_key'
+        ));
+    }
+
+    /** @test */
+    public function it_return_custom_user()
+    {
+        $this->actingAs((new CustomerUser())->forceFill([
+            'id' => 1,
+            'username' => 'username',
+            'password' => 'password',
+            'email' => 'email'
+        ]));
+
+        $this->assertSame(["id" => 1, "username" => "username", "password" => "password", "email" => "email"], $this->larabug->getUser());
+    }
+
+    /** @test */
+    public function it_return_custom_user_with_to_larabug()
+    {
+        $this->actingAs((new CustomerUserWithToLarabug())->forceFill([
+            'id' => 1,
+            'username' => 'username',
+            'password' => 'password',
+            'email' => 'email'
+        ]));
+
+        $this->assertSame(["username" => "username", "email" => "email"], $this->larabug->getUser());
+    }
+
+    /** @test */
+    public function it_returns_nothing_for_ghost()
+    {
+        $this->assertSame(null, $this->larabug->getUser());
+    }
+}
+
+class CustomerUser extends AuthUser
+{
+    protected $guarded = [];
+}
+
+class CustomerUserWithToLarabug extends CustomerUser
+{
+    public function toLarabug()
+    {
+        return [
+            'username' => $this->username,
+            'email' => $this->email
+        ];
+    }
+}


### PR DESCRIPTION
Moved the `getUser`-part from the `Http\Client` to the main-part of the Larabug-app.

Added a `toLarabug` method-check for the AuthUser Model, so you can overwrite this in your own AuthUser Model for more (or less, or other) information

Ditched `Cartalyst\Sentinel\Sentinel`