### PR TITLE
Removed Logging/Tap - PHPUnit 9+

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>


### PR DESCRIPTION
Logging/tap is removed/deprecated by PHPUnit 9+, so lets remove it