### PR TITLE
The `defer` property was deprecated in 5.8 and removed in 6.0 +

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,13 +11,6 @@ use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 class ServiceProvider extends BaseServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Bootstrap the application events.
      */
     public function boot()
@@ -45,7 +38,7 @@ class ServiceProvider extends BaseServiceProvider
 
         // Map any routes
         $this->mapLaraBugApiRoutes();
-        
+
         // Create an alias to the larabug-js-client.blade.php include
         Blade::include('larabug::larabug-js-client', 'larabugJavaScriptClient');
     }


### PR DESCRIPTION
The `defer` boolean property was deprecated in 5.8 and removed in 6.0 +, so lets remove it

https://laravel.com/docs/5.8/upgrade#deferred-service-providers