### PR TITLE
adding larabug/fake, assertSent/assertNotSent/assertNothingSent

### DIFF
--- a/src/Facade.php
+++ b/src/Facade.php
@@ -2,8 +2,26 @@
 
 namespace LaraBug;
 
+use LaraBug\Fakes\LaraBugFake;
+use LaraBug\Http\Client;
+
+/**
+ * @method static void assertSent($throwable, $callback = null)
+ * @method static void assertRequestsSent(int $count)
+ * @method static void assertNotSent($throwable, $callback = null)
+ * @method static void assertNothingSent()
+ */
 class Facade extends \Illuminate\Support\Facades\Facade
 {
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return void
+     */
+    public static function fake()
+    {
+        static::swap(new LaraBugFake(new Client('login_key', 'project_key')));
+    }
 
     /**
      * Get the registered name of the component.

--- a/src/Fakes/LaraBugFake.php
+++ b/src/Fakes/LaraBugFake.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace LaraBug\Fakes;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class LaraBugFake extends \LaraBug\LaraBug
+{
+    /** @var array */
+    public $exceptions = [];
+
+    /**
+     * @param int $expectedCount
+     */
+    public function assertRequestsSent(int $expectedCount)
+    {
+        PHPUnit::assertCount($expectedCount, $this->exceptions);
+    }
+
+    /**
+     * @param mixed $throwable
+     * @param callable|null $callback
+     */
+    public function assertNotSent($throwable, $callback = null)
+    {
+        $collect = collect($this->exceptions[$throwable] ?? []);
+
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        $filtered = $collect->filter(function ($arguments) use ($callback) {
+            return $callback($arguments);
+        });
+
+        PHPUnit::assertTrue($filtered->count() == 0);
+    }
+
+    public function assertNothingSent()
+    {
+        PHPUnit::assertCount(0, $this->exceptions);
+    }
+
+    /**
+     * @param mixed $throwable
+     * @param callable|null $callback
+     */
+    public function assertSent($throwable, $callback = null)
+    {
+        $collect = collect($this->exceptions[$throwable] ?? []);
+
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        $filtered = $collect->filter(function ($arguments) use ($callback) {
+            return $callback($arguments);
+        });
+
+        PHPUnit::assertTrue($filtered->count() > 0);
+    }
+
+    public function handle(\Throwable $exception, $fileType = 'php', array $customData = [])
+    {
+        $this->exceptions[get_class($exception)][] = $exception;
+    }
+}
+

--- a/tests/Fakes/LaraBugFakeTest.php
+++ b/tests/Fakes/LaraBugFakeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LaraBug\Tests\Fakes;
+
+use LaraBug\Facade as LarabugFacade;
+use LaraBug\Tests\TestCase;
+
+class LaraBugFakeTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        LarabugFacade::fake();
+
+        $this->app['config']['logging.channels.larabug'] = ['driver' => 'larabug'];
+        $this->app['config']['logging.default'] = 'larabug';
+        $this->app['config']['larabug.environments'] = ['testing'];
+    }
+
+    /** @test */
+    public function it_will_sent_exception_to_larabug_if_exception_is_thrown()
+    {
+        $this->app['router']->get('/exception', function () {
+            throw new \Exception('Exception');
+        });
+
+        $this->get('/exception');
+
+        LarabugFacade::assertSent(\Exception::class);
+
+        LarabugFacade::assertSent(\Exception::class, function (\Throwable $throwable) {
+            $this->assertSame('Exception', $throwable->getMessage());
+
+            return true;
+        });
+
+        LarabugFacade::assertNotSent(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+    }
+
+    /** @test */
+    public function it_will_sent_nothing_to_larabug_if_no_exceptions_thrown()
+    {
+        LarabugFacade::fake();
+
+        $this->app['router']->get('/nothing', function () {
+            //
+        });
+
+        $this->get('/nothing');
+
+        LarabugFacade::assertNothingSent();
+    }
+}


### PR DESCRIPTION
Adding a Larabug/Fake, so 'mocking' will be easier ..

```php
LarabugFacade::fake();

$this->app['router']->get('/exception', function () {
    throw new \Exception('Exception');
});

$this->get('/exception');

LarabugFacade::assertSent(\Exception::class);
```