### PR TITLE
Remove default values from config

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'login_key' => env('LB_KEY', 'LB_KEY'),
+    'login_key' => env('LB_KEY', ''),
 
     /*
     |--------------------------------------------------------------------------
@@ -24,7 +24,7 @@ return [
     |
     */
 
-    'project_key' => env('LB_PROJECT_KEY', 'LB_PROJECT_KEY'),
+    'project_key' => env('LB_PROJECT_KEY', ''),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The current config setup provides default values 'LB_KEY' and 'LB_PROJECT_KEY' if it can't find provided values.

The LaraBug:test command only checks if the key returns a value, so the display shows `✓ [Larabug] Found login key` when you have no values (or forgot to clear the cached file) which is very confusing.

No values means in the case of not adding the .env keys (or adding blank keys) the test command will warn no values were found.