### PR TITLE
Add more keys to default blacklist config

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -36,7 +36,7 @@ return [
     */
 
     'environments' => [
-        'production'
+        'production',
     ],
 
     /*
@@ -86,8 +86,10 @@ return [
     */
 
     'blacklist' => [
+        'authorization',
+        'current_password',
         'password',
-        'authorization'
+        'password_confirmation',
     ],
 
     /*


### PR DESCRIPTION
Add `current_password` and `password_confirmation` to default blacklist.

They are also included by default in `Handler::$dontFlash` in a fresh Laravel app.