### PR TITLE
Add support for installation on a lumen project

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -78,5 +78,11 @@ After that you have configured the LaraBug channel you can add it to the stack s
     //...
 ],
 ```
+
+PS: If you are using lumen, maybe you doesn't have the `logging.php` file. So, you can use default logging file from framework core.
+```bash
+php -r "file_exists('config/') || mkdir('config/'); copy('vendor/laravel/lumen-framework/config/logging.php', 'config/logging.php');"
+```
+
 ## License
 The larabug package is open source software licensed under the [license MIT](http://opensource.org/licenses/MIT)

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,7 +10,7 @@ Laravel 5.8/6.x/7.x/8.x package for logging errors to [larabug.com](https://www.
 [![Build Status](https://github.com/larabug/larabug/workflows/tests/badge.svg)](https://github.com/larabug/larabug/actions)
 [![Total Downloads](https://poser.pugx.org/larabug/larabug/d/total.svg)](https://packagist.org/packages/larabug/larabug)
 
-## Installation 
+## Installation on laravel
 You can install the package through Composer.
 ```bash
 composer require larabug/larabug
@@ -23,6 +23,28 @@ php artisan vendor:publish --provider="LaraBug\ServiceProvider"
 And adjust config file (`config/larabug.php`) with your desired settings.
 
 Note: by default only production environments will report errors. To modify this edit your larabug configuration.
+
+## Installation on lumen
+You can install the package through Composer.
+```bash
+composer require larabug/larabug
+```
+
+Copy the config file (`larabug.php`) to lumen config directory.
+```bash
+php -r "file_exists('config/') || mkdir('config/'); copy('vendor/larabug/larabug/config/larabug.php', 'config/larabug.php');"
+```
+And adjust config file (`config/larabug.php`) with your desired settings.
+
+In `bootstrap/app.php` you will need to:
+- Register the larabug config file:
+    ```php
+    $app->configure('larabug');
+    ```
+- Register larabug service provider:
+    ```php
+    $app->register(LaraBug\ServiceProvider::class);
+    ```
 
 ## Configuration variables
 All that is left to do is to define 2 env configuration variables.

--- a/.github/README.md
+++ b/.github/README.md
@@ -37,6 +37,10 @@ php -r "file_exists('config/') || mkdir('config/'); copy('vendor/larabug/larabug
 And adjust config file (`config/larabug.php`) with your desired settings.
 
 In `bootstrap/app.php` you will need to:
+- Uncomment this line:
+    ```php
+    $app->withFacades();
+    ```
 - Register the larabug config file:
     ```php
     $app->configure('larabug');
@@ -79,7 +83,8 @@ After that you have configured the LaraBug channel you can add it to the stack s
 ],
 ```
 
-PS: If you are using lumen, maybe you doesn't have the `logging.php` file. So, you can use default logging file from framework core.
+PS: If you are using lumen, maybe you doesn't have the `logging.php` file. So, you can use default logging file from
+framework core and make changes above.
 ```bash
 php -r "file_exists('config/') || mkdir('config/'); copy('vendor/laravel/lumen-framework/config/logging.php', 'config/logging.php');"
 ```

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -191,7 +191,7 @@ class LaraBug
         if (count($lines) < $count) {
             $count = count($lines) - $data['line'];
         }
-        
+
         for ($i = -1 * abs($count); $i <= abs($count); $i++) {
             $data['executor'][] = $this->getLineInfo($lines, $data['line'], $i);
         }
@@ -303,7 +303,7 @@ class LaraBug
      */
     public function getUser()
     {
-        if (function_exists('auth') && auth()->check()) {
+        if (function_exists('auth') && auth()->hasResolvedGuards() && auth()->check()) {
             /** @var \Illuminate\Contracts\Auth\Authenticatable $user */
             $user = auth()->user();
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,12 +18,12 @@ class ServiceProvider extends BaseServiceProvider
         // Publish configuration file
         if (function_exists('config_path')) {
             $this->publishes([
-                __DIR__.'/../config/larabug.php' => config_path('larabug.php'),
+                __DIR__ . '/../config/larabug.php' => config_path('larabug.php'),
             ]);
         }
 
         // Register views
-        $this->app['view']->addNamespace('larabug', __DIR__.'/../resources/views');
+        $this->app['view']->addNamespace('larabug', __DIR__ . '/../resources/views');
 
         // Register facade
         if (class_exists(\Illuminate\Foundation\AliasLoader::class)) {
@@ -48,7 +48,7 @@ class ServiceProvider extends BaseServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/larabug.php', 'larabug');
+        $this->mergeConfigFrom(__DIR__ . '/../config/larabug.php', 'larabug');
 
         $this->app->singleton('larabug', function ($app) {
             return new LaraBug(new \LaraBug\Http\Client(
@@ -70,8 +70,14 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function mapLaraBugApiRoutes()
     {
-        Route::namespace('\LaraBug\Http\Controllers')
-            ->prefix('larabug-api')
-            ->group(__DIR__.'/../routes/api.php');
+        Route::group(
+            [
+                'namespace' => '\LaraBug\Http\Controllers',
+                'prefix' => 'larabug-api'
+            ],
+            function ($router) {
+                require __DIR__ . '/../routes/api.php';
+            }
+        );
     }
 }


### PR DESCRIPTION
Two little adaptations on code is necessary to turn it possible an installation on lumen micro framework:

1. The way the routes are registred;
2. A check of guards on getUser().

The documentation was also updated.