### PR TITLE
Report request parameters

### DIFF
--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -175,6 +175,7 @@ class LaraBug
             'COOKIE' => $this->filterVariables(Request::cookie()),
             'SESSION' => $this->filterVariables(Request::hasSession() ? Session::all() : []),
             'HEADERS' => $this->filterVariables(Request::header()),
+            'PARAMETERS' => $this->filterVariables(Request::all())
         ];
 
         $data['storage'] = array_filter($data['storage']);
@@ -220,7 +221,7 @@ class LaraBug
                     $variables[$key] = $this->filterVariables($val);
                 }
                 if (in_array(strtolower($key), $this->blacklist)) {
-                    unset($variables[$key]);
+                    $variables[$key] = '***';
                 }
             });
 

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -220,8 +220,10 @@ class LaraBug
                 if (is_array($val)) {
                     $variables[$key] = $this->filterVariables($val);
                 }
-                if (in_array(strtolower($key), $this->blacklist)) {
-                    $variables[$key] = '***';
+                foreach($this->blacklist as $filter) {
+                    if(Str::is($filter, strtolower($key))) {
+                        $variables[$key] = '***';
+                    }
                 }
             });
 


### PR DESCRIPTION
This pr adds adds request parameters to the reported data. (closes https://github.com/LaraBug/LaraBug/issues/51)

1. Parameters values determined in `larabug.blacklist` will not be reported
2. `filterValue`does not remove the array key, but sets the value to `***`, by this one can see if a header/parameter exists
3. You may now add filters like `*token*` to the blacklist