### PR TITLE
Remove weird bytes from if statement

### DIFF
--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -218,7 +218,7 @@ class LaraBug
                     $variables[$key] = $this->filterVariables($val);
                 }
                 foreach($this->blacklist as $filter) {
-                    if(Str::is($filter, strtolower($key))) {
+                    if (Str::is($filter, strtolower($key))) {
                         $variables[$key] = '***';
                     }
                 }


### PR DESCRIPTION
phpstorm interprets it as NBSP, it shows as `C2A0` in a hex editor