### PR TITLE
Add Laravel 9 support

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -3,7 +3,7 @@
 </p>
 
 # LaraBug
-Laravel 6.x/8.x/9.x package for logging errors to [larabug.com](https://www.larabug.com)
+Laravel 6.x/7.x/8.x/9.x package for logging errors to [larabug.com](https://www.larabug.com)
 
 [![Software License](https://poser.pugx.org/larabug/larabug/license.svg)](LICENSE.md)
 [![Latest Version on Packagist](https://poser.pugx.org/larabug/larabug/v/stable.svg)](https://packagist.org/packages/larabug/larabug)

--- a/.github/README.md
+++ b/.github/README.md
@@ -3,7 +3,7 @@
 </p>
 
 # LaraBug
-Laravel 6.x/7.x/8.x package for logging errors to [larabug.com](https://www.larabug.com)
+Laravel 6.x/8.x/9.x package for logging errors to [larabug.com](https://www.larabug.com)
 
 [![Software License](https://poser.pugx.org/larabug/larabug/license.svg)](LICENSE.md)
 [![Latest Version on Packagist](https://poser.pugx.org/larabug/larabug/v/stable.svg)](https://packagist.org/packages/larabug/larabug)

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 7.4]
+                php: [8.1, 8.0, 7.4]
                 laravel: [8.*, 6.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
@@ -22,6 +22,11 @@ jobs:
                       testbench: 6.*
                     - laravel: 6.*
                       testbench: 4.*
+                exclude:
+                    - php: 8.1
+                      laravel: 6.*
+                    - php: 8.1
+                      laravel: 8.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 7.4, 7.3]
+                php: [8.0, 7.4]
                 laravel: [8.*, 6.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,15 +14,19 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.0, 7.4]
-                laravel: [8.*, 6.*]
+                laravel: [9.*, 8.*, 6.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
+                    - laravel: 9.*
+                      testbench: 7.*
                     - laravel: 8.*
                       testbench: 6.*
                     - laravel: 6.*
                       testbench: 4.*
                 exclude:
+                    - php: 7.4
+                      laravel: 9.*
                     - php: 8.1
                       laravel: 6.*
                     - php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.0, 7.4]
-                laravel: [9.*, 8.*, 6.*]
+                laravel: [9.*, 8.*, 7.*, 6.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
@@ -22,6 +22,8 @@ jobs:
                       testbench: 7.*
                     - laravel: 8.*
                       testbench: 6.*
+                    - laravel: 7.*
+                      testbench: 5.*
                     - laravel: 6.*
                       testbench: 4.*
                 exclude:
@@ -29,6 +31,8 @@ jobs:
                       laravel: 9.*
                     - php: 8.1
                       laravel: 6.*
+                    - php: 8.1
+                      laravel: 7.*
                     - php: 8.1
                       laravel: 8.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,14 +14,12 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.0, 7.4, 7.3]
-                laravel: [8.*, 7.*, 6.*]
+                laravel: [8.*, 6.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
                     - laravel: 8.*
                       testbench: 6.*
-                    - laravel: 7.*
-                      testbench: 5.*
                     - laravel: 6.*
                       testbench: 4.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ composer.lock
 vendor
 coverage
 .idea
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,11 +9,11 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->name('*.php')
     ->notName('*.blade.php');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config)
     ->setRules([
         '@PSR2' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'length'],
+        'array_syntax' => true,
+        'ordered_imports' => ['sort_algorithm' => 'length'],
         'no_unused_imports' => true,
         'single_quote' => true,
     ])

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,19 @@
 {
     "name": "larabug/larabug",
-    "description": "Laravel 5.8/6.x/7.x/8.x bug notifier",
+    "description": "Laravel 6.x/8.x bug notifier",
     "keywords": [
         "laravel",
         "log",
         "error"
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "guzzlehttp/guzzle": "^6.0.2|^7.0",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "php": "^7.2.5 || ^8.0",
+        "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
+        "illuminate/support": "^6.0 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0 || ^6.0",
         "mockery/mockery": "^1.3.3 || ^1.4.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "illuminate/support": "^6.0 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^4.0 || ^6.0",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "mockery/mockery": "^1.3.3 || ^1.4.2",
+        "orchestra/testbench": "^4.0 || ^6.0",
         "phpunit/phpunit": "^8.5.23 || ^9.5.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "larabug/larabug",
-    "description": "Laravel 6.x/8.x/9.x bug notifier",
+    "description": "Laravel 6.x/7.x/8.x/9.x bug notifier",
     "keywords": [
         "laravel",
         "log",
@@ -9,12 +9,12 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
-        "illuminate/support": "^6.0 || ^8.0 || ^9.0"
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
         "mockery/mockery": "^1.3.3 || ^1.4.2",
-        "orchestra/testbench": "^4.0 || ^6.0 || ^7.0",
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^8.5.23 || ^9.5.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "error"
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
         "illuminate/support": "^6.0 || ^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "larabug/larabug",
-    "description": "Laravel 6.x/8.x bug notifier",
+    "description": "Laravel 6.x/8.x/9.x bug notifier",
     "keywords": [
         "laravel",
         "log",
@@ -9,12 +9,12 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
-        "illuminate/support": "^6.0 || ^8.0"
+        "illuminate/support": "^6.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
         "mockery/mockery": "^1.3.3 || ^1.4.2",
-        "orchestra/testbench": "^4.0 || ^6.0",
+        "orchestra/testbench": "^4.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^8.5.23 || ^9.5.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "orchestra/testbench": "^4.0 || ^6.0",
-        "mockery/mockery": "^1.3.3 || ^1.4.2"
+        "mockery/mockery": "^1.3.3 || ^1.4.2",
+        "phpunit/phpunit": "^8.5.23 || ^9.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -5,11 +5,11 @@ namespace LaraBug;
 use Throwable;
 use LaraBug\Http\Client;
 use Illuminate\Support\Str;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
-use Illuminate\Http\UploadedFile;
 
 class LaraBug
 {
@@ -233,11 +233,7 @@ class LaraBug
      */
     public function shouldParameterValueBeFiltered($value)
     {
-        if ($value instanceof UploadFile) {
-            return true;
-        }
-
-        return false;
+        return $value instanceof UploadedFile;
     }
 
     /**


### PR DESCRIPTION
Add Laravel 9 support, run test on PHP 8.1, upgrade PHP-CS-Fixer and drop support for unsupported versions of Laravel and PHP.