### PR TITLE
Fix 422 error when sending Exceptions with no message

### DIFF
--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -155,7 +155,7 @@ class LaraBug
         $data['host'] = Request::server('SERVER_NAME');
         $data['method'] = Request::method();
         $data['fullUrl'] = Request::fullUrl();
-        $data['exception'] = $exception->getMessage() ?? 'Exception with no message';
+        $data['exception'] = $exception->getMessage() ?? '-';
         $data['error'] = $exception->getTraceAsString();
         $data['line'] = $exception->getLine();
         $data['file'] = $exception->getFile();

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -155,7 +155,7 @@ class LaraBug
         $data['host'] = Request::server('SERVER_NAME');
         $data['method'] = Request::method();
         $data['fullUrl'] = Request::fullUrl();
-        $data['exception'] = $exception->getMessage();
+        $data['exception'] = $exception->getMessage() ?? 'Exception with no message';
         $data['error'] = $exception->getTraceAsString();
         $data['line'] = $exception->getLine();
         $data['file'] = $exception->getFile();


### PR DESCRIPTION
Sometimes, when the package is sending Exceptions to LaraBug API, it returns the HTTP error `422` due to empty message on them.

### Steps to reproduce

Just throw an Exception with no message on anywhere in your code:

```php
throw new \Exception();
```

And now capture the error on line `94/95` of `./src/LaraBug.php` file like this:

```php
$rawResponse = $this->logError($data);
dd($rawResponse->getBody()->getContents());
```

The LaraBug API will return:

```json
{ "error": "Did not receive the correct parameters to process this exception" }
```

### Solution

I added a Null Coalescing operator on `getExceptionData()` to fill the Exception's message with a default value if not exists.