### PR TITLE
Convert test to Pest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,28 +13,18 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.0, 7.4]
-                laravel: [9.*, 8.*, 7.*, 6.*]
+                php: [8.2, 8.1, 8.0]
+                laravel: [^9.51.0, ^8.83.27]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
-                    - laravel: 9.*
-                      testbench: 7.*
-                    - laravel: 8.*
-                      testbench: 6.*
-                    - laravel: 7.*
-                      testbench: 5.*
-                    - laravel: 6.*
-                      testbench: 4.*
+                    - laravel: ^9.51.0
+                      testbench: ^7.22.0
+                    - laravel: ^8.83.27
+                      testbench: ^6.25.1
                 exclude:
-                    - php: 7.4
-                      laravel: 9.*
                     - php: 8.1
-                      laravel: 6.*
-                    - php: 8.1
-                      laravel: 7.*
-                    - php: 8.1
-                      laravel: 8.*
+                      laravel: ^8.83.27
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -55,4 +45,4 @@ jobs:
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Execute tests
-                run: vendor/bin/phpunit
+                run: vendor/bin/pest --ci

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "scripts": {
         "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage-html build/coverage",
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/pest --coverage-html build/coverage",
         "format": "vendor/bin/php-cs-fixer fix"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,18 @@
         "error"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "illuminate/support": "8.83.27 || ^9.51.0",
+        "nesbot/carbon": "^2.66"
     },
     "require-dev": {
+        "composer-runtime-api": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "mockery/mockery": "^1.3.3 || ^1.4.2",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-        "phpunit/phpunit": "^8.5.23 || ^9.5.12"
+        "mockery/mockery": "^1.3.3",
+        "orchestra/testbench": "^6.25.1 || ^7.22.0",
+        "pestphp/pest": "^1.22.4",
+        "pestphp/pest-plugin-laravel": "^1.4"
     },
     "autoload": {
         "psr-4": {
@@ -28,8 +31,8 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage-html build/coverage",
         "format": "vendor/bin/php-cs-fixer fix"
     },
     "extra": {
@@ -49,5 +52,10 @@
             "homepage": "http://www.dennissmink.nl",
             "role": "Owner"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -8,21 +9,24 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="LaraBug Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="LaraBug Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,12 @@
+<?php
+
+use LaraBug\Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+
+uses(TestCase::class)
+    ->beforeEach(function () {
+        if (version_compare(app()->version(), '9.0.0', '>=')) {
+            Http::preventStrayRequests();
+        }
+    })
+    ->in(__DIR__);

--- a/tests/Support/CustomerUser.php
+++ b/tests/Support/CustomerUser.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraBug\Tests\Support;
+
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class CustomerUser extends AuthUser
+{
+    protected $guarded = [];
+}

--- a/tests/Support/CustomerUserWithToLarabug.php
+++ b/tests/Support/CustomerUserWithToLarabug.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraBug\Tests\Support;
+
+use LaraBug\Concerns\Larabugable;
+
+class CustomerUserWithToLarabug extends CustomerUser implements Larabugable
+{
+    public function toLarabug(): array
+    {
+        return [
+            'username' => $this->username,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/tests/Support/Mocks/LaraBugClient.php
+++ b/tests/Support/Mocks/LaraBugClient.php
@@ -1,30 +1,26 @@
 <?php
 
-namespace LaraBug\Tests\Mocks;
+declare(strict_types=1);
 
+namespace LaraBug\Tests\Support\Mocks;
+
+use LaraBug\Http\Client;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 
-class LaraBugClient extends \LaraBug\Http\Client
+class LaraBugClient extends Client
 {
-    const RESPONSE_ID = 'test';
+    public const RESPONSE_ID = 'test';
 
-    /** @var array */
-    protected $requests = [];
+    protected array $requests = [];
 
-    /**
-     * @param array $exception
-     */
-    public function report($exception)
+    public function report($exception): Response
     {
         $this->requests[] = $exception;
 
         return new Response(200, [], json_encode(['id' => self::RESPONSE_ID]));
     }
 
-    /**
-     * @param int $expectedCount
-     */
     public function assertRequestsSent(int $expectedCount)
     {
         Assert::assertCount($expectedCount, $this->requests);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,25 +3,10 @@
 namespace LaraBug\Tests;
 
 use LaraBug\ServiceProvider;
-use Illuminate\Foundation\Application;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    /**
-     * @param Application $app
-     * @return array
-     */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [ServiceProvider::class];
     }

--- a/tests/TestCommandTest.php
+++ b/tests/TestCommandTest.php
@@ -1,80 +1,78 @@
 <?php
 
-namespace LaraBug\Tests;
+declare(strict_types=1);
 
 use LaraBug\LaraBug;
-use LaraBug\Tests\Mocks\LaraBugClient;
+use LaraBug\Commands\TestCommand;
 
-class TestCommandTest extends TestCase
-{
-    /** @test */
-    public function it_detects_if_the_login_key_is_set()
-    {
-        $this->app['config']['larabug.login_key'] = '';
+use function Pest\Laravel\artisan;
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✗ [LaraBug] Could not find your login key, set this in your .env')
-            ->assertExitCode(0);
+use function PHPUnit\Framework\assertEquals;
 
-        $this->app['config']['larabug.login_key'] = 'test';
+use LaraBug\Tests\Support\Mocks\LaraBugClient;
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✓ [Larabug] Found login key')
-            ->assertExitCode(0);
-    }
+it('detects if the login key is set', function () {
+    config(['larabug.login_key' => '']);
 
-    /** @test */
-    public function it_detects_if_the_project_key_is_set()
-    {
-        $this->app['config']['larabug.project_key'] = '';
+    artisan(TestCommand::class)
+        ->expectsOutput('✗ [LaraBug] Could not find your login key, set this in your .env')
+        ->assertSuccessful();
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✗ [LaraBug] Could not find your project key, set this in your .env')
-            ->assertExitCode(0);
+    config(['larabug.login_key' => 'test']);
 
-        $this->app['config']['larabug.project_key'] = 'test';
+    artisan(TestCommand::class)
+        ->expectsOutput('✓ [Larabug] Found login key')
+        ->assertSuccessful();
+});
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✓ [Larabug] Found project key')
-            ->assertExitCode(0);
-    }
+it('detects if the project key is set', function () {
+    config(['larabug.project_key' => '']);
 
-    /** @test */
-    public function it_detects_that_its_running_in_the_correct_environment()
-    {
-        $this->app['config']['app.env'] = 'production';
-        $this->app['config']['larabug.environments'] = [];
+    artisan(TestCommand::class)
+        ->expectsOutput('✗ [LaraBug] Could not find your project key, set this in your .env')
+        ->assertSuccessful();
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✗ [LaraBug] Environment (production) not allowed to send errors to LaraBug, set this in your config')
-            ->assertExitCode(0);
+    config(['larabug.project_key' => 'test']);
 
-        $this->app['config']['larabug.environments'] = ['production'];
+    artisan(TestCommand::class)
+        ->expectsOutput('✓ [Larabug] Found project key')
+        ->assertSuccessful();
+});
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✓ [Larabug] Correct environment found (' . config('app.env') . ')')
-            ->assertExitCode(0);
-    }
+it('detects that its running in the correct environment', function () {
+    config([
+        'app.env' => 'production',
+        'larabug.environments' =>[]
+    ]);
 
-    /** @test */
-    public function it_detects_that_it_fails_to_send_to_larabug()
-    {
-        $this->artisan('larabug:test')
-            ->expectsOutput('✗ [LaraBug] Failed to send exception to LaraBug')
-            ->assertExitCode(0);
+    artisan(TestCommand::class)
+        ->expectsOutput('✗ [LaraBug] Environment (production) not allowed to send errors to LaraBug, set this in your config')
+        ->assertSuccessful();
 
-        $this->app['config']['larabug.environments'] = [
-            'testing',
-        ];
-        $this->app['larabug'] = new LaraBug($this->client = new LaraBugClient(
-            'login_key',
-            'project_key'
-        ));
+    config([
+        'larabug.environments' => ['production'],
+    ]);
 
-        $this->artisan('larabug:test')
-            ->expectsOutput('✓ [LaraBug] Sent exception to LaraBug with ID: '.LaraBugClient::RESPONSE_ID)
-            ->assertExitCode(0);
+    artisan(TestCommand::class)
+        ->expectsOutput('✓ [Larabug] Correct environment found (' . config('app.env') . ')')
+        ->assertSuccessful();
+});
 
-        $this->assertEquals(LaraBugClient::RESPONSE_ID, $this->app['larabug']->getLastExceptionId());
-    }
-}
+it('detects that it fails to send to larabug', function () {
+    artisan(TestCommand::class)
+        ->expectsOutput('✗ [LaraBug] Failed to send exception to LaraBug')
+        ->assertSuccessful();
+
+    config(['larabug.environments' => ['testing']]);
+
+    $this->app['larabug'] = new LaraBug($this->client = new LaraBugClient(
+        'login_key',
+        'project_key'
+    ));
+
+    artisan(TestCommand::class)
+        ->expectsOutput('✓ [LaraBug] Sent exception to LaraBug with ID: '.LaraBugClient::RESPONSE_ID)
+        ->assertSuccessful();
+
+    assertEquals(LaraBugClient::RESPONSE_ID, $this->app['larabug']->getLastExceptionId());
+});


### PR DESCRIPTION
- Add test in PHP 8.2 in Github action
- Drop support Laravel 6 and 7
- Drop support PHP 7.4
- Use semantic version and set minimum version with latest patch
- Add `Http::preventStrayRequests()` when testing in Laravel 9
- Move support test fake class
- Move fake test clas to `LaraBug\Tests\Support` namespace
- Run `phpunit --migrate-configuration`
- Add `XDEBUG_MODE=coverage` on test-coverage alias