### PR TITLE
Use laravel `Http` facade for easy configuring request

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,19 +14,19 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.0, 7.4]
-                laravel: [9.*, 8.*]
+                laravel: [^9.51.0, ^8.83.27]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
-                    - laravel: 9.*
+                    - laravel: ^9.51.0
                       testbench: 7.*
-                    - laravel: 8.*
+                    - laravel: ^8.83.27
                       testbench: 6.*
                 exclude:
                     - php: 7.4
-                      laravel: 9.*
+                      laravel: ^9.51.0
                     - php: 8.1
-                      laravel: 8.*
+                      laravel: ^8.83.27
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,8 +29,6 @@ jobs:
                       laravel: 10.*
                     - php: 8.0
                       laravel: 10.*
-                    - php: 8.1
-                      laravel: 10.*
                     - php: 7.4
                       laravel: ^9.51.0
                     - php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,9 +26,9 @@ jobs:
                       testbench: 6.*
                 exclude:
                     - php: 7.4
-                      laravel: 10.*
+                      laravel: ^10.1.0
                     - php: 8.0
-                      laravel: 10.*
+                      laravel: ^10.1.0
                     - php: 7.4
                       laravel: ^9.51.0
                     - php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,8 @@ jobs:
                       laravel: 10.*
                     - php: 8.0
                       laravel: 10.*
+                    - php: 8.1
+                      laravel: 10.*
                     - php: 7.4
                       laravel: ^9.51.0
                     - php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.0, 7.4]
-                laravel: [9.*, 8.*, 7.*, 6.*]
+                laravel: [9.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
@@ -22,17 +22,9 @@ jobs:
                       testbench: 7.*
                     - laravel: 8.*
                       testbench: 6.*
-                    - laravel: 7.*
-                      testbench: 5.*
-                    - laravel: 6.*
-                      testbench: 4.*
                 exclude:
                     - php: 7.4
                       laravel: 9.*
-                    - php: 8.1
-                      laravel: 6.*
-                    - php: 8.1
-                      laravel: 7.*
                     - php: 8.1
                       laravel: 8.*
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
-        "illuminate/support": "^8.0 || ^9.0"
+        "illuminate/support": "^8.83.27 || ^9.51.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
+        "guzzlehttp/guzzle": "^7.5",
         "illuminate/support": "^8.83.27 || ^9.51.0 || ^10.1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "illuminate/support": "^8.0 || ^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
         "mockery/mockery": "^1.3.3 || ^1.4.2",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "orchestra/testbench": "^6.0 || ^7.0",
         "phpunit/phpunit": "^8.5.23 || ^9.5.12"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -8,21 +9,24 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="LaraBug Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="LaraBug Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,23 +2,17 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         cacheDirectory="build/phpunit"
+         backupStaticProperties="false">
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>
     </include>
     <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
     </report>
   </coverage>
   <testsuites>


### PR DESCRIPTION
- Set minimum latest patch support of laravel
- Drop support laravel 6 and 7