### PR TITLE
Add re-entry guards for safe self-tracking

### DIFF
--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -26,6 +26,15 @@ class LaraBug
     private static $customContext = [];
 
     /**
+     * Re-entry guard. Set while handle() is executing so any exception
+     * thrown *inside* the capture path (HTTP errors, serialization, etc.)
+     * can't recursively trigger another capture and blow the stack.
+     *
+     * @var bool
+     */
+    private static $capturing = false;
+
+    /**
      * @param Client $client
      */
     public function __construct(Client $client)
@@ -62,73 +71,102 @@ class LaraBug
      */
     public function handle(Throwable $exception, $fileType = 'php', array $customData = [])
     {
-        if ($this->isSkipEnvironment()) {
+        // Drop any capture that re-enters while another capture is still in flight.
+        // Without this, an error thrown inside logError() would be caught by
+        // Laravel's handler and fed back into handle(), looping forever.
+        if (self::$capturing) {
             return false;
         }
 
-        $data = $this->getExceptionData($exception);
+        self::$capturing = true;
 
-        if ($this->isSkipException($data['class'])) {
-            return false;
-        }
-
-        if ($this->isSleepingException($data)) {
-            return false;
-        }
-
-        if ($fileType == 'javascript') {
-            $data['fullUrl'] = $customData['url'];
-            $data['file'] = $customData['file'];
-            $data['file_type'] = $fileType;
-            $data['error'] = $customData['message'];
-            $data['exception'] = $customData['stack'];
-            $data['line'] = $customData['line'];
-            $data['class'] = null;
-
-            $count = config('larabug.lines_count');
-
-            if ($count > 50) {
-                $count = 12;
+        try {
+            if ($this->isSkipEnvironment()) {
+                return false;
             }
 
-            $lines = file($data['file']);
-            $data['executor'] = [];
+            $data = $this->getExceptionData($exception);
 
-            for ($i = -1 * abs($count); $i <= abs($count); $i++) {
-                $currentLine = $data['line'] + $i;
+            if ($this->isSkipException($data['class'])) {
+                return false;
+            }
 
-                $index = $currentLine - 1;
+            if ($this->isSleepingException($data)) {
+                return false;
+            }
 
-                if (!array_key_exists($index, $lines)) {
-                    continue;
+            if ($fileType == 'javascript') {
+                $data['fullUrl'] = $customData['url'];
+                $data['file'] = $customData['file'];
+                $data['file_type'] = $fileType;
+                $data['error'] = $customData['message'];
+                $data['exception'] = $customData['stack'];
+                $data['line'] = $customData['line'];
+                $data['class'] = null;
+
+                $count = config('larabug.lines_count');
+
+                if ($count > 50) {
+                    $count = 12;
                 }
 
-                $data['executor'][] = [
-                    'line_number' => $currentLine,
-                    'line' => $lines[$index],
-                ];
+                $lines = file($data['file']);
+                $data['executor'] = [];
+
+                for ($i = -1 * abs($count); $i <= abs($count); $i++) {
+                    $currentLine = $data['line'] + $i;
+
+                    $index = $currentLine - 1;
+
+                    if (!array_key_exists($index, $lines)) {
+                        continue;
+                    }
+
+                    $data['executor'][] = [
+                        'line_number' => $currentLine,
+                        'line' => $lines[$index],
+                    ];
+                }
+
+                $data['executor'] = array_filter($data['executor']);
             }
 
-            $data['executor'] = array_filter($data['executor']);
-        }
+            $rawResponse = $this->logError($data);
 
-        $rawResponse = $this->logError($data);
+            if (!$rawResponse) {
+                return false;
+            }
 
-        if (!$rawResponse) {
+            $response = json_decode($rawResponse->getBody()->getContents());
+
+            if (isset($response->id)) {
+                $this->setLastExceptionId($response->id);
+            }
+
+            if (config('larabug.sleep') !== 0) {
+                $this->addExceptionToSleep($data);
+            }
+
+            return $response;
+        } catch (Throwable $inner) {
+            // Anything that blows up inside capture must NOT re-enter Laravel's
+            // exception handler — that would loop back into this method. Swallow
+            // to stderr and let the outer process keep going.
+            error_log('[LaraBug] capture failed: '.$inner->getMessage());
+
             return false;
+        } finally {
+            self::$capturing = false;
         }
+    }
 
-        $response = json_decode($rawResponse->getBody()->getContents());
-
-        if (isset($response->id)) {
-            $this->setLastExceptionId($response->id);
-        }
-
-        if (config('larabug.sleep') !== 0) {
-            $this->addExceptionToSleep($data);
-        }
-
-        return $response;
+    /**
+     * @internal Used by tests and the queue tracking path to check whether
+     * a capture is currently in flight.
+     */
+    public static function isCapturing(): bool
+    {
+        return self::$capturing;
     }
 
     /**

--- a/src/Queue/JobMonitor.php
+++ b/src/Queue/JobMonitor.php
@@ -116,7 +116,25 @@ class JobMonitor
             return false;
         }
 
+        // Don't track queue events while a regular exception capture is in flight —
+        // prevents the queue tracking path from re-entering the send pipeline
+        // while it is already being used by LaraBug::handle().
+        if (\LaraBug\LaraBug::isCapturing()) {
+            return false;
+        }
+
         $jobClass = $job->resolveName();
+
+        // Never track SDK-internal jobs. This is a hard-coded safety rail on top
+        // of the user-configurable ignore list below: when the LaraBug package is
+        // installed inside the LaraBug SaaS itself (dogfooding), we never want the
+        // ingest queue jobs shipping themselves back to the server.
+        if (is_string($jobClass) && (
+            str_starts_with($jobClass, 'LaraBug\\')
+            || str_starts_with($jobClass, 'Larabug\\')
+        )) {
+            return false;
+        }
 
         // Check ignore list
         foreach ($this->config['jobs']['ignore_jobs'] ?? [] as $ignoredJob) {


### PR DESCRIPTION
## Summary

Makes it safe to install `larabug/larabug` inside the LaraBug SaaS itself without triggering infinite loops in either the exception path or the queue-tracking path.

## Changes

### Exception capture re-entry guard (`src/LaraBug.php`)

- Added a static `\$capturing` flag in `LaraBug::handle()`.
- Any call that re-enters while another capture is in flight is dropped immediately (return `false`).
- The body of `handle()` is wrapped in try/catch/finally. If anything throws during capture (HTTP errors, JSON serialization, stack trace analysis, etc.), the error goes to `error_log()` instead of bubbling — prevents Laravel's exception handler from catching the inner throwable and recursively calling `handle()` again.
- New public `LaraBug::isCapturing()` so other parts of the SDK can ask whether a capture is currently running.

### Queue tracking hard blocks (`src/Queue/JobMonitor.php`)

- `shouldTrack()` now returns `false` immediately when `LaraBug::isCapturing()` is true — stops the queue-tracking path from re-entering the send pipeline while an exception capture is already using it.
- `shouldTrack()` also hard-blocks any job class in the `LaraBug\\` / `Larabug\\` namespace, above and beyond the user-configurable `ignore_jobs` list. This is the safety rail for the dogfooding case: if the LaraBug SaaS has the SDK installed and dispatches a LaraBug-namespaced job (e.g. some future internal maintenance job), it won't ship itself back.

## Compatibility

- **Backwards compatible.** The new static method is additive. The behavioural change (dropping recursive captures) only fires in pathological cases that previously caused stack overflows. No public API is removed or renamed.
- Recommend a **minor** version bump to `3.7.0` on release.

## Test plan

- [ ] Install in an app, throw an exception, verify it still reports
- [ ] Install in an app that has a failing queue job, verify `JobFailed` still reports
- [ ] Install inside a LaraBug-like app that catches its own exceptions and forwards them to the SDK; verify no stack overflow
- [ ] Dispatch a `LaraBug\Foo` job manually, verify the queue tracker silently skips it

🤖 Generated with [Claude Code](https://claude.com/claude-code)