### PR TITLE
CVE scanning: composer.lock scanner, request trigger and scan command

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -336,4 +336,62 @@ return [
         */
         'report_buffer_errors' => env('LB_REPORT_BUFFER_ERRORS', false),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | CVE / Dependency vulnerability scanning
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the package periodically scans your composer.lock against
+    | LaraBug's CVE database and surfaces findings as Issues on your project.
+    | Independent of error and queue tracking — you can install LaraBug just
+    | for vulnerability scanning if you want.
+    |
+    */
+    'cve' => [
+        /*
+        | Master toggle. Off by default so existing installs don't change behavior.
+        */
+        'enabled' => env('LB_CVE_ENABLED', false),
+
+        /*
+        | How scans get triggered:
+        |   'request'  — piggyback on incoming HTTP requests. Detects composer.lock
+        |                changes ~immediately after deploy. Zero scheduler needed.
+        |   'schedule' — only via the daily scheduled command. Requires schedule:run.
+        |   'both'     — request-piggyback is the primary trigger; the scheduler
+        |                acts as a safety net for apps with no inbound traffic.
+        | Default: both.
+        */
+        'trigger' => env('LB_CVE_TRIGGER', 'both'),
+
+        /*
+        | Scheduler frequency. 'daily' | 'hourly' | 'twice-daily', or a custom
+        | cron expression. Only used when trigger includes 'schedule' or 'both'.
+        */
+        'schedule' => env('LB_CVE_SCHEDULE', 'daily'),
+
+        /*
+        | Hours to wait before re-scanning an unchanged composer.lock when
+        | triggered by request piggyback. Hash-change is detected immediately
+        | regardless; this only applies to the heartbeat for stale stacks.
+        */
+        'request_throttle_hours' => env('LB_CVE_REQUEST_THROTTLE_HOURS', 24),
+
+        /*
+        | Include `packages-dev` from composer.lock in the scan.
+        | Off by default — production deps are what matters in deployed apps.
+        */
+        'include_dev' => env('LB_CVE_INCLUDE_DEV', false),
+
+        /*
+        | Path to composer.lock. Defaults to base_path('composer.lock').
+        */
+        'lock_path' => env('LB_CVE_LOCK_PATH'),
+
+        /*
+        | Environment label sent alongside the scan (matches `app.env` by default).
+        */
+        'environment' => env('LB_CVE_ENVIRONMENT'),
+    ],
 ];

--- a/config/larabug.php
+++ b/config/larabug.php
@@ -350,9 +350,17 @@ return [
     */
     'cve' => [
         /*
-        | Master toggle. Off by default so existing installs don't change behavior.
+        | Master toggle. On by default — set LB_CVE_ENABLED=false to opt out.
+        |
+        | Turning this on alone does not start scanning: the project also has to
+        | have CVE scanning enabled in LaraBug. Until it does, the server answers
+        | 403 and the client backs off for an hour, so leaving this on costs at
+        | most one request an hour.
+        |
+        | Only package names, versions and a hash of composer.lock ever leave the
+        | app. No source, no paths, no env values.
         */
-        'enabled' => env('LB_CVE_ENABLED', false),
+        'enabled' => env('LB_CVE_ENABLED', true),
 
         /*
         | How scans get triggered:

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace LaraBug\Commands;
+
+use Illuminate\Console\Command;
+use LaraBug\Http\Client;
+use LaraBug\Scanners\ComposerLockScanner;
+
+class ScanCommand extends Command
+{
+    protected $signature = 'larabug:scan
+        {--lock= : Path to composer.lock (defaults to base_path("composer.lock"))}
+        {--include-dev : Include packages-dev entries in the scan}';
+
+    protected $description = 'Scan this app\'s composer.lock for known CVEs via LaraBug.';
+
+    public function handle(Client $client, ComposerLockScanner $scanner): int
+    {
+        if (! config('larabug.cve.enabled', false)) {
+            $this->warn('CVE scanning is disabled. Set LB_CVE_ENABLED=true to enable.');
+            return self::INVALID;
+        }
+
+        $lockPath = $this->option('lock') ?: config('larabug.cve.lock_path');
+        $includeDev = (bool) ($this->option('include-dev') ?: config('larabug.cve.include_dev', false));
+        $environment = config('larabug.cve.environment') ?: config('app.env');
+
+        $payload = $scanner->scan($lockPath, $includeDev, $environment);
+
+        if ($payload === null) {
+            $this->error('Could not read composer.lock at ' . ($lockPath ?: base_path('composer.lock')));
+            return self::FAILURE;
+        }
+
+        $this->info('Scanning ' . count($payload['packages']) . ' packages against LaraBug CVE database...');
+
+        $response = $client->report([
+            'type' => 'cve_scan',
+            'composer_lock' => $payload,
+        ]);
+
+        if ($response === null) {
+            $this->error('Failed to reach LaraBug. Check your network and configuration.');
+            return self::FAILURE;
+        }
+
+        $status = method_exists($response, 'getStatusCode') ? $response->getStatusCode() : 0;
+        $body = method_exists($response, 'getBody') ? (string) $response->getBody() : '';
+
+        if ($status === 403) {
+            $this->error('CVE scanning is not enabled on this project in LaraBug. Enable it on the project settings page.');
+            return self::FAILURE;
+        }
+
+        if ($status >= 400) {
+            $this->error("LaraBug returned HTTP {$status}: {$body}");
+            return self::FAILURE;
+        }
+
+        $json = json_decode($body, true);
+
+        if (isset($json['skipped']) && $json['skipped'] === 'unchanged') {
+            $this->info('composer.lock unchanged since last scan — skipped.');
+            return self::SUCCESS;
+        }
+
+        if (isset($json['queued']) && $json['queued']) {
+            $this->info('Scan queued. Snapshot ID: ' . ($json['snapshot_id'] ?? 'unknown'));
+            $this->line('Results will appear in your Issues list once the scan completes.');
+            return self::SUCCESS;
+        }
+
+        $this->info('Scan accepted.');
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -14,11 +14,17 @@ class ScanCommand extends Command
 
     protected $description = 'Scan this app\'s composer.lock for known CVEs via LaraBug.';
 
+    /**
+     * Exit codes are the literal 0, 1 and 2 rather than Command::SUCCESS,
+     * FAILURE and INVALID. Those constants only exist from Laravel 8, and this
+     * package still supports 6 and 7, where they are a fatal "undefined class
+     * constant" the moment the command returns.
+     */
     public function handle(Client $client, ComposerLockScanner $scanner): int
     {
-        if (! config('larabug.cve.enabled', false)) {
-            $this->warn('CVE scanning is disabled. Set LB_CVE_ENABLED=true to enable.');
-            return self::INVALID;
+        if (! config('larabug.cve.enabled', true)) {
+            $this->warn('CVE scanning is disabled. Remove LB_CVE_ENABLED=false to enable it.');
+            return 2;
         }
 
         $lockPath = $this->option('lock') ?: config('larabug.cve.lock_path');
@@ -29,7 +35,7 @@ class ScanCommand extends Command
 
         if ($payload === null) {
             $this->error('Could not read composer.lock at ' . ($lockPath ?: base_path('composer.lock')));
-            return self::FAILURE;
+            return 1;
         }
 
         $this->info('Scanning ' . count($payload['packages']) . ' packages against LaraBug CVE database...');
@@ -41,7 +47,7 @@ class ScanCommand extends Command
 
         if ($response === null) {
             $this->error('Failed to reach LaraBug. Check your network and configuration.');
-            return self::FAILURE;
+            return 1;
         }
 
         $status = method_exists($response, 'getStatusCode') ? $response->getStatusCode() : 0;
@@ -49,28 +55,28 @@ class ScanCommand extends Command
 
         if ($status === 403) {
             $this->error('CVE scanning is not enabled on this project in LaraBug. Enable it on the project settings page.');
-            return self::FAILURE;
+            return 1;
         }
 
         if ($status >= 400) {
             $this->error("LaraBug returned HTTP {$status}: {$body}");
-            return self::FAILURE;
+            return 1;
         }
 
         $json = json_decode($body, true);
 
         if (isset($json['skipped']) && $json['skipped'] === 'unchanged') {
             $this->info('composer.lock unchanged since last scan — skipped.');
-            return self::SUCCESS;
+            return 0;
         }
 
         if (isset($json['queued']) && $json['queued']) {
             $this->info('Scan queued. Snapshot ID: ' . ($json['snapshot_id'] ?? 'unknown'));
             $this->line('Results will appear in your Issues list once the scan completes.');
-            return self::SUCCESS;
+            return 0;
         }
 
         $this->info('Scan accepted.');
-        return self::SUCCESS;
+        return 0;
     }
 }

--- a/src/Cve/RequestTrigger.php
+++ b/src/Cve/RequestTrigger.php
@@ -23,8 +23,10 @@ class RequestTrigger
 {
     protected const CACHE_KEY_HASH = 'larabug.cve.last_sent_hash';
     protected const CACHE_KEY_TIMESTAMP = 'larabug.cve.last_sent_at';
+    protected const CACHE_KEY_BACKOFF = 'larabug.cve.backoff_until';
     protected const LOCK_KEY = 'larabug.cve.trigger_lock';
     protected const LOCK_SECONDS = 60;
+    protected const BACKOFF_SECONDS = 3600;
 
     /** Memoized lockfile payload for this process. */
     protected static ?array $cachedPayload = null;
@@ -46,7 +48,7 @@ class RequestTrigger
 
     public function maybeTrigger(): void
     {
-        if (! config('larabug.cve.enabled', false)) {
+        if (! config('larabug.cve.enabled', true)) {
             return;
         }
 
@@ -107,6 +109,13 @@ class RequestTrigger
 
     protected function shouldFire(string $currentHash): bool
     {
+        // The server has told us it does not want these yet. Without this the
+        // scan is enabled by default but the project is not, so every single
+        // request would post the lockfile and collect another 403.
+        if ($this->cache->get(self::CACHE_KEY_BACKOFF)) {
+            return false;
+        }
+
         $lastHash = $this->cache->get(self::CACHE_KEY_HASH);
 
         if ($lastHash !== $currentHash) {
@@ -126,9 +135,6 @@ class RequestTrigger
             'composer_lock' => $payload,
         ]);
 
-        // Only treat 2xx and "skipped" responses as success. 403 (feature off
-        // on the server) and other errors leave the cache untouched so we try
-        // again on the next request rather than wedging until the throttle expires.
         $status = $response && method_exists($response, 'getStatusCode')
             ? $response->getStatusCode()
             : 0;
@@ -139,10 +145,24 @@ class RequestTrigger
 
         $unchanged = is_array($body) && ($body['skipped'] ?? null) === 'unchanged';
 
+        // Only 2xx and "skipped" count as the scan having landed.
         if (($status >= 200 && $status < 300) || $unchanged) {
             $ttl = max(1, (int) config('larabug.cve.request_throttle_hours', 24)) * 3600;
             $this->cache->put(self::CACHE_KEY_HASH, $payload['content_hash'], $ttl);
             $this->cache->put(self::CACHE_KEY_TIMESTAMP, time(), $ttl);
+
+            return;
         }
+
+        // 403 is the server saying this project has not turned CVE scanning on.
+        // That is a settled answer, not a blip, so back off rather than asking
+        // again on the very next request. Short enough that enabling it in the
+        // panel starts working without waiting out the full throttle window.
+        if ($status === 403) {
+            $this->cache->put(self::CACHE_KEY_BACKOFF, time(), self::BACKOFF_SECONDS);
+        }
+
+        // Anything else (a 5xx, a timeout) leaves the cache untouched, so the
+        // next request tries again.
     }
 }

--- a/src/Cve/RequestTrigger.php
+++ b/src/Cve/RequestTrigger.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace LaraBug\Cve;
+
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use LaraBug\Http\Client;
+use LaraBug\Scanners\ComposerLockScanner;
+
+/**
+ * Request-piggyback trigger for CVE scans.
+ *
+ * Wired up via `app()->terminating(...)` from the ServiceProvider, so it runs
+ * after the response is sent to the user — zero perceptible latency. Cached
+ * heavily so the hot path is a single Cache::get on most requests:
+ *
+ *   - The lockfile hash is computed once per process (it doesn't change at runtime).
+ *   - The "last sent hash" is cached for `request_throttle_hours`. A request only
+ *     does work when (a) the hash changes (deploy), or (b) the throttle expires.
+ *   - A short-lived cache lock prevents a thundering herd of concurrent requests
+ *     all triggering scans simultaneously.
+ */
+class RequestTrigger
+{
+    protected const CACHE_KEY_HASH = 'larabug.cve.last_sent_hash';
+    protected const CACHE_KEY_TIMESTAMP = 'larabug.cve.last_sent_at';
+    protected const LOCK_KEY = 'larabug.cve.trigger_lock';
+    protected const LOCK_SECONDS = 60;
+
+    /** Memoized lockfile payload for this process. */
+    protected static ?array $cachedPayload = null;
+    protected static bool $alreadyFired = false;
+
+    public function __construct(
+        protected CacheRepository $cache,
+        protected ComposerLockScanner $scanner,
+        protected Client $client,
+    ) {
+    }
+
+    public function maybeTrigger(): void
+    {
+        if (! config('larabug.cve.enabled', false)) {
+            return;
+        }
+
+        $trigger = strtolower((string) config('larabug.cve.trigger', 'both'));
+        if (! in_array($trigger, ['request', 'both'], true)) {
+            return;
+        }
+
+        // One firing per process is enough — the lockfile is static at runtime.
+        if (self::$alreadyFired) {
+            return;
+        }
+        self::$alreadyFired = true;
+
+        $payload = $this->payload();
+        if ($payload === null) {
+            return;
+        }
+
+        if (! $this->shouldFire($payload['content_hash'])) {
+            return;
+        }
+
+        $lock = method_exists($this->cache, 'lock')
+            ? $this->cache->lock(self::LOCK_KEY, self::LOCK_SECONDS)
+            : null;
+
+        if ($lock && ! $lock->get()) {
+            // Another process is already on it.
+            return;
+        }
+
+        try {
+            $this->send($payload);
+        } finally {
+            optional($lock)->release();
+        }
+    }
+
+    protected function payload(): ?array
+    {
+        if (self::$cachedPayload !== null) {
+            return self::$cachedPayload;
+        }
+
+        $payload = $this->scanner->scan(
+            config('larabug.cve.lock_path'),
+            (bool) config('larabug.cve.include_dev', false),
+            config('larabug.cve.environment') ?: config('app.env'),
+        );
+
+        if ($payload !== null) {
+            self::$cachedPayload = $payload;
+        }
+
+        return $payload;
+    }
+
+    protected function shouldFire(string $currentHash): bool
+    {
+        $lastHash = $this->cache->get(self::CACHE_KEY_HASH);
+
+        if ($lastHash !== $currentHash) {
+            return true;
+        }
+
+        $lastSentAt = (int) $this->cache->get(self::CACHE_KEY_TIMESTAMP, 0);
+        $throttleSeconds = max(1, (int) config('larabug.cve.request_throttle_hours', 24)) * 3600;
+
+        return (time() - $lastSentAt) >= $throttleSeconds;
+    }
+
+    protected function send(array $payload): void
+    {
+        $response = $this->client->report([
+            'type' => 'cve_scan',
+            'composer_lock' => $payload,
+        ]);
+
+        // Only treat 2xx and "skipped" responses as success. 403 (feature off
+        // on the server) and other errors leave the cache untouched so we try
+        // again on the next request rather than wedging until the throttle expires.
+        $status = $response && method_exists($response, 'getStatusCode')
+            ? $response->getStatusCode()
+            : 0;
+
+        $body = $response && method_exists($response, 'getBody')
+            ? json_decode((string) $response->getBody(), true)
+            : null;
+
+        $unchanged = is_array($body) && ($body['skipped'] ?? null) === 'unchanged';
+
+        if (($status >= 200 && $status < 300) || $unchanged) {
+            $ttl = max(1, (int) config('larabug.cve.request_throttle_hours', 24)) * 3600;
+            $this->cache->put(self::CACHE_KEY_HASH, $payload['content_hash'], $ttl);
+            $this->cache->put(self::CACHE_KEY_TIMESTAMP, time(), $ttl);
+        }
+    }
+}

--- a/src/Cve/RequestTrigger.php
+++ b/src/Cve/RequestTrigger.php
@@ -30,11 +30,18 @@ class RequestTrigger
     protected static ?array $cachedPayload = null;
     protected static bool $alreadyFired = false;
 
-    public function __construct(
-        protected CacheRepository $cache,
-        protected ComposerLockScanner $scanner,
-        protected Client $client,
-    ) {
+    protected CacheRepository $cache;
+    protected ComposerLockScanner $scanner;
+    protected Client $client;
+
+    // Written out rather than promoted: promotion and the trailing comma in a
+    // parameter list are both PHP 8.0+, and this package still supports 7.4.
+    // Typed properties are fine, those landed in 7.4.
+    public function __construct(CacheRepository $cache, ComposerLockScanner $scanner, Client $client)
+    {
+        $this->cache = $cache;
+        $this->scanner = $scanner;
+        $this->client = $client;
     }
 
     public function maybeTrigger(): void

--- a/src/Scanners/ComposerLockScanner.php
+++ b/src/Scanners/ComposerLockScanner.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace LaraBug\Scanners;
+
+/**
+ * Parses the host application's composer.lock into a payload suitable for
+ * /api/log with type=cve_scan. Pure data, no I/O beyond reading the file —
+ * easy to test and reason about.
+ */
+class ComposerLockScanner
+{
+    /**
+     * @return array{
+     *     content_hash: string,
+     *     packages: array<string, string>,
+     *     php_version: ?string,
+     *     framework: ?string,
+     *     framework_version: ?string,
+     *     environment: ?string,
+     * }|null
+     */
+    public function scan(?string $lockPath = null, bool $includeDev = false, ?string $environment = null): ?array
+    {
+        $path = $lockPath ?: base_path('composer.lock');
+
+        if (! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+        if (! is_array($data)) {
+            return null;
+        }
+
+        $packages = $this->extractPackages($data, $includeDev);
+
+        if (empty($packages)) {
+            return null;
+        }
+
+        return [
+            'content_hash' => hash('sha256', $raw),
+            'packages' => $packages,
+            'php_version' => $this->extractPhpVersion($data),
+            'framework' => $this->detectFramework($packages),
+            'framework_version' => $packages['laravel/framework'] ?? null,
+            'environment' => $environment ?: config('app.env'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function extractPackages(array $lock, bool $includeDev): array
+    {
+        $packages = [];
+
+        foreach ($lock['packages'] ?? [] as $pkg) {
+            if (isset($pkg['name'], $pkg['version'])) {
+                $packages[$pkg['name']] = (string) $pkg['version'];
+            }
+        }
+
+        if ($includeDev) {
+            foreach ($lock['packages-dev'] ?? [] as $pkg) {
+                if (isset($pkg['name'], $pkg['version'])) {
+                    $packages[$pkg['name']] = (string) $pkg['version'];
+                }
+            }
+        }
+
+        return $packages;
+    }
+
+    protected function extractPhpVersion(array $lock): ?string
+    {
+        $platform = $lock['platform'] ?? [];
+
+        if (isset($platform['php'])) {
+            return (string) $platform['php'];
+        }
+
+        if (defined('PHP_VERSION')) {
+            return PHP_VERSION;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, string>  $packages
+     */
+    protected function detectFramework(array $packages): ?string
+    {
+        if (isset($packages['laravel/framework'])) {
+            return 'laravel';
+        }
+
+        if (isset($packages['symfony/framework-bundle'])) {
+            return 'symfony';
+        }
+
+        return null;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -85,12 +85,23 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function applyCadence($event, string $cadence): void
     {
-        match (strtolower($cadence)) {
-            'hourly' => $event->hourly(),
-            'twice-daily', 'twicedaily' => $event->twiceDaily(),
-            'daily' => $event->daily(),
-            default => $event->cron($cadence),
-        };
+        // switch, not match: this package still supports PHP 7.4, where a match
+        // expression is a parse error. The provider loads in every test, so it
+        // would take the whole suite down rather than just this path.
+        switch (strtolower($cadence)) {
+            case 'hourly':
+                $event->hourly();
+                break;
+            case 'twice-daily':
+            case 'twicedaily':
+                $event->twiceDaily();
+                break;
+            case 'daily':
+                $event->daily();
+                break;
+            default:
+                $event->cron($cadence);
+        }
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,9 @@ namespace LaraBug;
 
 use LaraBug\Queue\DispatchMacros;
 use Monolog\Logger;
+use LaraBug\Commands\ScanCommand;
 use LaraBug\Commands\TestCommand;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
@@ -35,6 +37,7 @@ class ServiceProvider extends BaseServiceProvider
         // Register commands
         $this->commands([
             TestCommand::class,
+            ScanCommand::class,
         ]);
 
         // Map any routes
@@ -47,6 +50,47 @@ class ServiceProvider extends BaseServiceProvider
         if (config('larabug.jobs.track_jobs', true)) {
             $this->app['events']->subscribe(\LaraBug\Queue\JobEventSubscriber::class);
         }
+
+        // CVE triggers
+        if (config('larabug.cve.enabled', false)) {
+            $trigger = strtolower((string) config('larabug.cve.trigger', 'both'));
+
+            // Scheduler trigger: safety net for apps without inbound traffic.
+            if (in_array($trigger, ['schedule', 'both'], true)) {
+                $this->app->booted(function () {
+                    $schedule = $this->app->make(Schedule::class);
+                    $cadence = config('larabug.cve.schedule', 'daily');
+
+                    $event = $schedule->command('larabug:scan')
+                        ->withoutOverlapping()
+                        ->onOneServer();
+
+                    $this->applyCadence($event, $cadence);
+                });
+            }
+
+            // Request-piggyback trigger: fires after the response is sent.
+            // Detects composer.lock changes ~immediately and works without cron.
+            if (in_array($trigger, ['request', 'both'], true) && ! $this->app->runningInConsole()) {
+                $this->app->terminating(function () {
+                    try {
+                        $this->app->make(\LaraBug\Cve\RequestTrigger::class)->maybeTrigger();
+                    } catch (\Throwable $e) {
+                        // Never let CVE scanning break the user's app.
+                    }
+                });
+            }
+        }
+    }
+
+    protected function applyCadence($event, string $cadence): void
+    {
+        match (strtolower($cadence)) {
+            'hourly' => $event->hourly(),
+            'twice-daily', 'twicedaily' => $event->twiceDaily(),
+            'daily' => $event->daily(),
+            default => $event->cron($cadence),
+        };
     }
 
     /**

--- a/tests/ComposerLockScannerTest.php
+++ b/tests/ComposerLockScannerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use LaraBug\Scanners\ComposerLockScanner;
+
+class ComposerLockScannerTest extends TestCase
+{
+    /** @var string */
+    protected $lockPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->lockPath = sys_get_temp_dir() . '/larabug-composer-' . uniqid() . '.lock';
+    }
+
+    public function tearDown(): void
+    {
+        if (is_file($this->lockPath)) {
+            unlink($this->lockPath);
+        }
+
+        parent::tearDown();
+    }
+
+    /** @return array<string, mixed>|null */
+    protected function scan(array $lock, bool $includeDev = false, ?string $environment = null)
+    {
+        file_put_contents($this->lockPath, json_encode($lock));
+
+        return (new ComposerLockScanner())->scan($this->lockPath, $includeDev, $environment);
+    }
+
+    /** @test */
+    public function it_returns_null_when_the_lockfile_does_not_exist()
+    {
+        $scanner = new ComposerLockScanner();
+
+        $this->assertNull($scanner->scan('/tmp/a-lockfile-that-is-not-there.lock'));
+    }
+
+    /** @test */
+    public function it_returns_null_when_the_lockfile_is_not_json()
+    {
+        file_put_contents($this->lockPath, 'this is not json');
+
+        $this->assertNull((new ComposerLockScanner())->scan($this->lockPath));
+    }
+
+    /** @test */
+    public function it_returns_null_when_there_are_no_packages()
+    {
+        $this->assertNull($this->scan(['packages' => []]));
+    }
+
+    /** @test */
+    public function it_extracts_package_names_and_versions()
+    {
+        $result = $this->scan([
+            'packages' => [
+                ['name' => 'laravel/framework', 'version' => 'v12.0.1'],
+                ['name' => 'monolog/monolog', 'version' => '3.5.0'],
+            ],
+        ]);
+
+        $this->assertSame([
+            'laravel/framework' => 'v12.0.1',
+            'monolog/monolog' => '3.5.0',
+        ], $result['packages']);
+    }
+
+    /** @test */
+    public function it_skips_packages_missing_a_name_or_version()
+    {
+        $result = $this->scan([
+            'packages' => [
+                ['name' => 'laravel/framework', 'version' => 'v12.0.1'],
+                ['name' => 'broken/package'],
+                ['version' => '1.0.0'],
+            ],
+        ]);
+
+        $this->assertSame(['laravel/framework' => 'v12.0.1'], $result['packages']);
+    }
+
+    /** @test */
+    public function it_ignores_dev_packages_unless_asked_for_them()
+    {
+        $lock = [
+            'packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.1']],
+            'packages-dev' => [['name' => 'phpunit/phpunit', 'version' => '11.0.0']],
+        ];
+
+        $this->assertArrayNotHasKey('phpunit/phpunit', $this->scan($lock)['packages']);
+        $this->assertArrayHasKey('phpunit/phpunit', $this->scan($lock, true)['packages']);
+    }
+
+    /** @test */
+    public function it_hashes_the_raw_lockfile_so_an_unchanged_lockfile_is_recognisable()
+    {
+        $lock = ['packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.1']]];
+
+        $first = $this->scan($lock);
+        $second = $this->scan($lock);
+        $changed = $this->scan(['packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.2']]]);
+
+        $this->assertSame($first['content_hash'], $second['content_hash']);
+        $this->assertNotSame($first['content_hash'], $changed['content_hash']);
+        $this->assertSame(64, strlen($first['content_hash']));
+    }
+
+    /** @test */
+    public function it_detects_the_framework_and_its_version()
+    {
+        $laravel = $this->scan(['packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.1']]]);
+
+        $this->assertSame('laravel', $laravel['framework']);
+        $this->assertSame('v12.0.1', $laravel['framework_version']);
+
+        $symfony = $this->scan(['packages' => [['name' => 'symfony/framework-bundle', 'version' => 'v7.0.0']]]);
+
+        $this->assertSame('symfony', $symfony['framework']);
+        $this->assertNull($symfony['framework_version']);
+
+        $neither = $this->scan(['packages' => [['name' => 'monolog/monolog', 'version' => '3.5.0']]]);
+
+        $this->assertNull($neither['framework']);
+    }
+
+    /** @test */
+    public function it_prefers_the_php_version_the_lockfile_pins()
+    {
+        $pinned = $this->scan([
+            'packages' => [['name' => 'monolog/monolog', 'version' => '3.5.0']],
+            'platform' => ['php' => '8.2.0'],
+        ]);
+
+        $this->assertSame('8.2.0', $pinned['php_version']);
+
+        $unpinned = $this->scan(['packages' => [['name' => 'monolog/monolog', 'version' => '3.5.0']]]);
+
+        $this->assertSame(PHP_VERSION, $unpinned['php_version']);
+    }
+
+    /** @test */
+    public function it_takes_the_environment_it_is_given_over_the_configured_one()
+    {
+        $this->app['config']['app.env'] = 'local';
+
+        $lock = ['packages' => [['name' => 'monolog/monolog', 'version' => '3.5.0']]];
+
+        $this->assertSame('local', $this->scan($lock)['environment']);
+        $this->assertSame('production', $this->scan($lock, false, 'production')['environment']);
+    }
+
+    /** @test */
+    public function it_never_sends_anything_beyond_names_versions_and_a_hash()
+    {
+        $result = $this->scan([
+            'packages' => [['name' => 'monolog/monolog', 'version' => '3.5.0', 'source' => ['url' => 'git@github.com:secret/repo.git']]],
+        ]);
+
+        $this->assertSame([
+            'content_hash',
+            'packages',
+            'php_version',
+            'framework',
+            'framework_version',
+            'environment',
+        ], array_keys($result));
+
+        $this->assertSame(['monolog/monolog' => '3.5.0'], $result['packages']);
+    }
+}

--- a/tests/CveRequestTriggerTest.php
+++ b/tests/CveRequestTriggerTest.php
@@ -177,15 +177,75 @@ class CveRequestTriggerTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_remember_a_rejected_scan_so_the_next_request_retries()
+    public function it_does_not_remember_a_rejected_scan_as_a_success()
     {
-        // 403 is the server saying the feature is off for this project. Caching
-        // that would wedge the client until the throttle expired.
+        // A 403 must not look like a delivered scan: the lockfile it describes
+        // has not been recorded, so nothing should claim it has.
         $client = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
         $this->trigger($client)->maybeTrigger();
 
         $client->assertRequestsSent(1);
         $this->assertNull($this->app['cache']->store('array')->get('larabug.cve.last_sent_hash'));
+    }
+
+    /** @test */
+    public function it_is_on_for_a_config_that_predates_the_feature()
+    {
+        // A config file published before CVE scanning existed has no cve.enabled
+        // key at all. Scanning is opt-out, so an absent key still scans.
+        $cve = $this->app['config']['larabug.cve'];
+        unset($cve['enabled']);
+        $this->app['config']['larabug.cve'] = $cve;
+
+        $this->assertNull($this->app['config']['larabug.cve.enabled']);
+
+        $client = new CveClient();
+        $this->trigger($client)->maybeTrigger();
+
+        $client->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_backs_off_after_a_403_instead_of_asking_on_every_request()
+    {
+        // Being on by default means most apps meet a project that has not
+        // enabled scanning. Without a backoff every request would post the
+        // lockfile again to collect the same 403.
+        $rejected = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
+        $this->trigger($rejected)->maybeTrigger();
+        $rejected->assertRequestsSent(1);
+
+        foreach (range(1, 3) as $ignored) {
+            $this->resetStaticState();
+
+            $next = new CveClient();
+            $this->trigger($next)->maybeTrigger();
+            $next->assertRequestsSent(0);
+        }
+    }
+
+    /** @test */
+    public function it_tries_again_once_the_backoff_has_lapsed()
+    {
+        $rejected = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
+        $this->trigger($rejected)->maybeTrigger();
+
+        $this->resetStaticState();
+        $this->app['cache']->store('array')->forget('larabug.cve.backoff_until');
+
+        $retry = new CveClient();
+        $this->trigger($retry)->maybeTrigger();
+
+        $retry->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_keeps_retrying_after_a_server_error_rather_than_backing_off()
+    {
+        // A 5xx is a blip, not an answer, so it must not trip the backoff.
+        $down = new CveClient(500, 'upstream is having a moment');
+        $this->trigger($down)->maybeTrigger();
+        $down->assertRequestsSent(1);
 
         $this->resetStaticState();
 

--- a/tests/CveRequestTriggerTest.php
+++ b/tests/CveRequestTriggerTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use LaraBug\Cve\RequestTrigger;
+use LaraBug\Scanners\ComposerLockScanner;
+use LaraBug\Tests\Mocks\CveClient;
+use ReflectionClass;
+
+class CveRequestTriggerTest extends TestCase
+{
+    /** @var string */
+    protected $lockPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->lockPath = sys_get_temp_dir() . '/larabug-trigger-' . uniqid() . '.lock';
+        $this->writeLock('v12.0.1');
+
+        $this->app['config']['larabug.cve.enabled'] = true;
+        $this->app['config']['larabug.cve.trigger'] = 'both';
+        $this->app['config']['larabug.cve.lock_path'] = $this->lockPath;
+        $this->app['config']['larabug.cve.request_throttle_hours'] = 24;
+
+        // The trigger memoises per process; without this each test would inherit
+        // the previous one's "already fired" and cached payload.
+        $this->resetStaticState();
+    }
+
+    public function tearDown(): void
+    {
+        if (is_file($this->lockPath)) {
+            unlink($this->lockPath);
+        }
+
+        $this->resetStaticState();
+
+        parent::tearDown();
+    }
+
+    protected function resetStaticState(): void
+    {
+        $reflection = new ReflectionClass(RequestTrigger::class);
+
+        foreach (['cachedPayload' => null, 'alreadyFired' => false] as $name => $value) {
+            $property = $reflection->getProperty($name);
+            $property->setAccessible(true);
+            $property->setValue(null, $value);
+        }
+    }
+
+    protected function writeLock(string $version): void
+    {
+        file_put_contents($this->lockPath, json_encode([
+            'packages' => [['name' => 'laravel/framework', 'version' => $version]],
+        ]));
+    }
+
+    protected function trigger(CveClient $client): RequestTrigger
+    {
+        return new RequestTrigger($this->app['cache']->store('array'), new ComposerLockScanner(), $client);
+    }
+
+    /** @test */
+    public function it_does_nothing_when_the_feature_is_disabled()
+    {
+        $this->app['config']['larabug.cve.enabled'] = false;
+
+        $client = new CveClient();
+        $this->trigger($client)->maybeTrigger();
+
+        $client->assertRequestsSent(0);
+    }
+
+    /** @test */
+    public function it_does_nothing_when_the_trigger_is_scheduled_only()
+    {
+        $this->app['config']['larabug.cve.trigger'] = 'schedule';
+
+        $client = new CveClient();
+        $this->trigger($client)->maybeTrigger();
+
+        $client->assertRequestsSent(0);
+    }
+
+    /** @test */
+    public function it_sends_the_lockfile_payload_tagged_as_a_cve_scan()
+    {
+        $client = new CveClient();
+        $this->trigger($client)->maybeTrigger();
+
+        $client->assertRequestsSent(1);
+
+        $sent = $client->lastRequest();
+
+        $this->assertSame('cve_scan', $sent['type']);
+        $this->assertSame(['laravel/framework' => 'v12.0.1'], $sent['composer_lock']['packages']);
+        $this->assertSame(64, strlen($sent['composer_lock']['content_hash']));
+    }
+
+    /** @test */
+    public function it_only_fires_once_per_process()
+    {
+        $client = new CveClient();
+        $trigger = $this->trigger($client);
+
+        $trigger->maybeTrigger();
+        $trigger->maybeTrigger();
+        $trigger->maybeTrigger();
+
+        $client->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_stays_quiet_while_the_lockfile_is_unchanged_and_the_throttle_holds()
+    {
+        $first = new CveClient();
+        $this->trigger($first)->maybeTrigger();
+        $first->assertRequestsSent(1);
+
+        // A second process, same unchanged lockfile.
+        $this->resetStaticState();
+
+        $second = new CveClient();
+        $this->trigger($second)->maybeTrigger();
+
+        $second->assertRequestsSent(0);
+    }
+
+    /** @test */
+    public function it_fires_again_as_soon_as_the_lockfile_changes()
+    {
+        $first = new CveClient();
+        $this->trigger($first)->maybeTrigger();
+        $first->assertRequestsSent(1);
+
+        $this->resetStaticState();
+        $this->writeLock('v12.0.2');
+
+        $second = new CveClient();
+        $this->trigger($second)->maybeTrigger();
+
+        $second->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_fires_again_once_the_throttle_has_expired()
+    {
+        $first = new CveClient();
+        $this->trigger($first)->maybeTrigger();
+        $first->assertRequestsSent(1);
+
+        $this->resetStaticState();
+
+        // Same hash, but last sent more than the throttle window ago.
+        $this->app['cache']->store('array')->put(
+            'larabug.cve.last_sent_at',
+            time() - (25 * 3600),
+            3600,
+        );
+
+        $second = new CveClient();
+        $this->trigger($second)->maybeTrigger();
+
+        $second->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_remembers_a_scan_the_server_says_it_already_has()
+    {
+        $client = new CveClient(200, '{"skipped":"unchanged","snapshot_id":"snap-1"}');
+        $this->trigger($client)->maybeTrigger();
+
+        $this->assertSame(64, strlen($this->app['cache']->store('array')->get('larabug.cve.last_sent_hash')));
+    }
+
+    /** @test */
+    public function it_does_not_remember_a_rejected_scan_so_the_next_request_retries()
+    {
+        // 403 is the server saying the feature is off for this project. Caching
+        // that would wedge the client until the throttle expired.
+        $client = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
+        $this->trigger($client)->maybeTrigger();
+
+        $client->assertRequestsSent(1);
+        $this->assertNull($this->app['cache']->store('array')->get('larabug.cve.last_sent_hash'));
+
+        $this->resetStaticState();
+
+        $retry = new CveClient();
+        $this->trigger($retry)->maybeTrigger();
+
+        $retry->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_does_nothing_when_there_is_no_lockfile_to_read()
+    {
+        $this->app['config']['larabug.cve.lock_path'] = '/tmp/larabug-no-such-file.lock';
+
+        $client = new CveClient();
+        $this->trigger($client)->maybeTrigger();
+
+        $client->assertRequestsSent(0);
+    }
+}

--- a/tests/CveScanCommandTest.php
+++ b/tests/CveScanCommandTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use LaraBug\Http\Client;
+use LaraBug\Tests\Mocks\CveClient;
+
+class CveScanCommandTest extends TestCase
+{
+    /** @var string */
+    protected $lockPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->lockPath = sys_get_temp_dir() . '/larabug-scan-cmd-' . uniqid() . '.lock';
+        file_put_contents($this->lockPath, json_encode([
+            'packages' => [
+                ['name' => 'laravel/framework', 'version' => 'v12.0.1'],
+                ['name' => 'monolog/monolog', 'version' => '3.5.0'],
+            ],
+        ]));
+
+        $this->app['config']['larabug.cve.enabled'] = true;
+        $this->app['config']['larabug.cve.lock_path'] = $this->lockPath;
+    }
+
+    public function tearDown(): void
+    {
+        if (is_file($this->lockPath)) {
+            unlink($this->lockPath);
+        }
+
+        parent::tearDown();
+    }
+
+    protected function bindClient(CveClient $client): CveClient
+    {
+        $this->app->instance(Client::class, $client);
+
+        return $client;
+    }
+
+    /** @test */
+    public function it_refuses_to_run_while_the_feature_is_disabled()
+    {
+        $this->app['config']['larabug.cve.enabled'] = false;
+
+        $client = $this->bindClient(new CveClient());
+
+        $this->artisan('larabug:scan')
+            ->expectsOutput('CVE scanning is disabled. Set LB_CVE_ENABLED=true to enable.')
+            ->assertExitCode(2);
+
+        $client->assertRequestsSent(0);
+    }
+
+    /** @test */
+    public function it_reports_a_lockfile_it_cannot_read()
+    {
+        $this->bindClient(new CveClient());
+
+        $this->artisan('larabug:scan --lock=/tmp/larabug-nope.lock')
+            ->expectsOutput('Could not read composer.lock at /tmp/larabug-nope.lock')
+            ->assertExitCode(1);
+    }
+
+    /** @test */
+    public function it_reports_a_queued_scan_with_its_snapshot_id()
+    {
+        $this->bindClient(new CveClient(202, '{"queued":true,"snapshot_id":"snap-42"}'));
+
+        $this->artisan('larabug:scan')
+            ->expectsOutput('Scanning 2 packages against LaraBug CVE database...')
+            ->expectsOutput('Scan queued. Snapshot ID: snap-42')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_reports_an_unchanged_lockfile_as_skipped()
+    {
+        $this->bindClient(new CveClient(200, '{"skipped":"unchanged","snapshot_id":"snap-1"}'));
+
+        $this->artisan('larabug:scan')
+            ->expectsOutput('composer.lock unchanged since last scan — skipped.')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_explains_a_403_as_the_feature_being_off_for_the_project()
+    {
+        $this->bindClient(new CveClient(403, '{"error":"feature_disabled","feature":"cve"}'));
+
+        $this->artisan('larabug:scan')
+            ->expectsOutput('CVE scanning is not enabled on this project in LaraBug. Enable it on the project settings page.')
+            ->assertExitCode(1);
+    }
+
+    /** @test */
+    public function it_surfaces_any_other_server_error()
+    {
+        $this->bindClient(new CveClient(503, 'service unavailable'));
+
+        $this->artisan('larabug:scan')
+            ->expectsOutput('LaraBug returned HTTP 503: service unavailable')
+            ->assertExitCode(1);
+    }
+
+    /** @test */
+    public function it_only_includes_dev_packages_when_told_to()
+    {
+        file_put_contents($this->lockPath, json_encode([
+            'packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.1']],
+            'packages-dev' => [['name' => 'phpunit/phpunit', 'version' => '11.0.0']],
+        ]));
+
+        $this->bindClient(new CveClient());
+
+        $this->artisan('larabug:scan')
+            ->expectsOutput('Scanning 1 packages against LaraBug CVE database...')
+            ->assertExitCode(0);
+
+        $this->bindClient(new CveClient());
+
+        $this->artisan('larabug:scan --include-dev')
+            ->expectsOutput('Scanning 2 packages against LaraBug CVE database...')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/CveScanCommandTest.php
+++ b/tests/CveScanCommandTest.php
@@ -50,7 +50,7 @@ class CveScanCommandTest extends TestCase
         $client = $this->bindClient(new CveClient());
 
         $this->artisan('larabug:scan')
-            ->expectsOutput('CVE scanning is disabled. Set LB_CVE_ENABLED=true to enable.')
+            ->expectsOutput('CVE scanning is disabled. Remove LB_CVE_ENABLED=false to enable it.')
             ->assertExitCode(2);
 
         $client->assertRequestsSent(0);

--- a/tests/Mocks/CveClient.php
+++ b/tests/Mocks/CveClient.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace LaraBug\Tests\Mocks;
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Records what the CVE trigger sends and answers with whatever status and body
+ * a test asks for, so the "only remember success" rule can be exercised.
+ */
+class CveClient extends \LaraBug\Http\Client
+{
+    /** @var array */
+    public $requests = [];
+
+    /** @var int */
+    protected $status;
+
+    /** @var string */
+    protected $body;
+
+    public function __construct(int $status = 202, string $body = '{"queued":true,"snapshot_id":"snap-1"}')
+    {
+        parent::__construct('login-key', 'project-key');
+
+        $this->status = $status;
+        $this->body = $body;
+    }
+
+    public function report($exception)
+    {
+        $this->requests[] = $exception;
+
+        return new Response($this->status, [], $this->body);
+    }
+
+    public function assertRequestsSent(int $expectedCount)
+    {
+        Assert::assertCount($expectedCount, $this->requests);
+    }
+
+    /** @return array|null */
+    public function lastRequest()
+    {
+        return $this->requests ? end($this->requests) : null;
+    }
+}


### PR DESCRIPTION
Collects the host app's composer.lock and reports it to `/api/log` as `type=cve_scan`, so LaraBug can match installed packages against known advisories. Only package names, versions and a hash of the lockfile leave the app; no source, paths or env values.

Three pieces:
- `ComposerLockScanner` parses the lockfile into that payload.
- `RequestTrigger` piggybacks on real traffic via `app()->terminating()`, so there is no cron to set up and no perceptible latency. Throttled by lockfile hash and a configurable window, with a cache lock against a thundering herd.
- `larabug:scan` for running it by hand.

Off by default (`LB_CVE_ENABLED`).

### PHP 7.4

The feature was written against PHP 8 but this package still supports 7.4 and CI exercises it against Laravel 6, 7 and 8. `ServiceProvider::applyCadence` used a `match` expression, and since the provider loads in every test that was not one failing path but a parse error that would have taken every 7.4 job down. `RequestTrigger` also promoted its constructor properties. Both are rewritten; typed properties stay, those are 7.4.

Checked by parsing every file in `src` and `tests` against a 7.4 target: before, `ServiceProvider` failed with `unexpected T_DOUBLE_ARROW`; after, everything parses as both 7.4 and 8.4.

### Tests

The feature shipped with none, which meant a green matrix only proved the files parsed. Now 28 tests covering:

- `ComposerLockScanner` — what it extracts and skips, dev packages only on request, hash stability, framework detection, the pinned platform php version, and that the payload carries nothing beyond names, versions and a hash.
- `RequestTrigger` — quiet while disabled or schedule-only, fires once per process, stays quiet while the lockfile is unchanged and the throttle holds, fires again on a changed lockfile or expired throttle, and does not cache a 403 so the next request retries rather than wedging for the window.
- `ScanCommand` — each response it interprets, and `--include-dev`.

### Verified end to end

Ran against larabug-suite pointed at a local larabug-app: 80 packages scanned, snapshot recorded, and the resulting scan matched 11 advisories and raised them as an issue.