### PR TITLE
Ship application logs from the package

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -411,14 +411,15 @@ return [
     | Ships application log lines to LaraBug, so the lines leading up to an
     | error are there when you open it.
     |
-    | Adding the channel to your stack in config/logging.php is the opt-in;
-    | nothing is sent until you do. Logs run at far higher volume than
-    | exceptions and count against your plan, so opt in deliberately.
+    | Naming the channel in your logging stack is the opt-in; nothing is sent
+    | until you do. Logs run at far higher volume than exceptions and count
+    | against your plan, so opt in deliberately.
     |
-    |   'stack' => [
-    |       'driver' => 'stack',
-    |       'channels' => ['single', 'larabug-logs'],
-    |   ],
+    |   LOG_STACK=single,larabug-logs
+    |
+    | The package defines the `larabug-logs` channel itself, so there is
+    | nothing to add to config/logging.php. Define a channel of that name
+    | yourself if you want different settings; yours wins.
     |
     */
 

--- a/config/larabug.php
+++ b/config/larabug.php
@@ -402,4 +402,63 @@ return [
         */
         'environment' => env('LB_CVE_ENVIRONMENT'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Logs
+    |--------------------------------------------------------------------------
+    |
+    | Ships application log lines to LaraBug, so the lines leading up to an
+    | error are there when you open it.
+    |
+    | Adding the channel to your stack in config/logging.php is the opt-in;
+    | nothing is sent until you do. Logs run at far higher volume than
+    | exceptions and count against your plan, so opt in deliberately.
+    |
+    |   'stack' => [
+    |       'driver' => 'stack',
+    |       'channels' => ['single', 'larabug-logs'],
+    |   ],
+    |
+    */
+
+    'logs' => [
+        /*
+        | Kill switch. Leave it on: the channel decides whether logs are sent.
+        | Set LB_LOGS_ENABLED=false to stop shipping without touching the
+        | logging config, for instance while debugging a noisy deploy.
+        */
+        'enabled' => env('LB_LOGS_ENABLED', true),
+
+        /*
+        | Minimum severity to send, as a PSR-3 level name. Shipping 'debug'
+        | from production is rarely what you want.
+        */
+        'level' => env('LB_LOGS_LEVEL', 'info'),
+
+        /*
+        | Lines held before a batch is sent. A request that logs fewer than
+        | this sends one batch when it terminates.
+        */
+        'batch_size' => env('LB_LOGS_BATCH_SIZE', 50),
+
+        /*
+        | Retries on a 5xx. A refused batch (402, 403, 422) is never retried
+        | and stops collection for the rest of the process.
+        */
+        'max_retries' => env('LB_LOGS_MAX_RETRIES', 3),
+
+        /*
+        | Ceiling on how many keys of one context or extra bag are sent. Log
+        | context routinely holds whole models, and the rest is dropped with a
+        | `_truncated` marker rather than shipping an object graph per line.
+        */
+        'max_context_keys' => env('LB_LOGS_MAX_CONTEXT_KEYS', 50),
+
+        /*
+        | Release identifier sent with every line, so a spike can be tied to a
+        | deploy. A commit sha or a version tag.
+        */
+        'release' => env('LB_LOGS_RELEASE'),
+    ],
 ];

--- a/src/Logger/LaraBugLogHandler.php
+++ b/src/Logger/LaraBugLogHandler.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace LaraBug\Logger;
+
+use DateTimeInterface;
+use JsonSerializable;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use Throwable;
+
+/**
+ * Ships log lines to LaraBug.
+ *
+ * Separate from LaraBugHandler on purpose. That one exists to turn a logged
+ * Throwable into an exception report and sits at ERROR; this one is interested
+ * in the ordinary lines around an error, so it runs at a much lower level and
+ * must stay cheap enough to sit in a request's hot path.
+ */
+class LaraBugLogHandler extends AbstractProcessingHandler
+{
+    /** @var LogBuffer */
+    protected $buffer;
+
+    /** @var array */
+    protected $config;
+
+    /**
+     * @param LogBuffer $buffer
+     * @param array $config
+     * @param int $level
+     * @param bool $bubble
+     */
+    public function __construct(LogBuffer $buffer, array $config = [], $level = Logger::DEBUG, bool $bubble = true)
+    {
+        $this->buffer = $buffer;
+        $this->config = $config;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @param array $record
+     */
+    protected function write($record): void
+    {
+        if (! $this->buffer->enabled()) {
+            return;
+        }
+
+        try {
+            $this->buffer->add($this->toPayload($record));
+        } catch (Throwable $e) {
+            // Never let shipping a log line break the call that wrote it.
+        }
+    }
+
+    /**
+     * Monolog 3 hands over a LogRecord object rather than an array, but it
+     * implements ArrayAccess over the same keys, so one accessor covers 1, 2
+     * and 3 without branching on the version.
+     *
+     * @param array|\ArrayAccess $record
+     * @return array
+     */
+    protected function toPayload($record): array
+    {
+        $context = $this->arrayValue($record, 'context');
+
+        // The exception object is what LaraBugHandler reports separately. Left
+        // in place it would be the single largest thing in the payload, and the
+        // interesting parts of it are already on the exception report.
+        unset($context['exception']);
+
+        return [
+            'timestamp' => $this->timestamp($record),
+            'level' => $this->level($record),
+            'channel' => (string) $this->value($record, 'channel', ''),
+            'message' => (string) $this->value($record, 'message', ''),
+            'context' => $this->normalize($context),
+            // Laravel's Context facade and every Monolog processor write here,
+            // not into context, so dropping it would lose most of what makes a
+            // line useful.
+            'extra' => $this->normalize($this->arrayValue($record, 'extra')),
+            'trace_id' => (string) $this->correlation($record, 'trace_id'),
+            'exception_id' => (string) $this->correlation($record, 'exception_id'),
+            'environment' => (string) ($this->config['environment'] ?? ''),
+            'release' => (string) ($this->config['release'] ?? ''),
+            'user_identifier' => (string) $this->correlation($record, 'user_identifier'),
+        ];
+    }
+
+    /**
+     * @param array|\ArrayAccess $record
+     * @return string
+     */
+    protected function timestamp($record): string
+    {
+        $datetime = $this->value($record, 'datetime');
+
+        if ($datetime instanceof DateTimeInterface) {
+            return $datetime->format('Y-m-d\TH:i:s.vP');
+        }
+
+        return date('Y-m-d\TH:i:s.000P');
+    }
+
+    /**
+     * @param array|\ArrayAccess $record
+     * @return string
+     */
+    protected function level($record): string
+    {
+        $name = $this->value($record, 'level_name');
+
+        // Monolog 3 replaced the int level with a Level enum, whose ->name is
+        // "Warning" rather than the "WARNING" earlier versions produced.
+        if (! is_string($name)) {
+            $level = $this->value($record, 'level');
+            $name = is_object($level) && isset($level->name) ? $level->name : 'info';
+        }
+
+        return strtolower($name);
+    }
+
+    /**
+     * Correlation ids travel in whichever bag the application happened to use,
+     * so both are checked rather than picking a side.
+     *
+     * @param array|\ArrayAccess $record
+     * @param string $key
+     * @return string
+     */
+    protected function correlation($record, string $key): string
+    {
+        foreach (['context', 'extra'] as $bag) {
+            $values = $this->arrayValue($record, $bag);
+
+            if (isset($values[$key]) && is_scalar($values[$key])) {
+                return (string) $values[$key];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Reduce a context bag to something that survives json_encode.
+     *
+     * Bounded on purpose: log context routinely holds whole models, and sending
+     * an object graph per line is how a logging integration turns into an
+     * outage.
+     *
+     * @param array $values
+     * @param int $depth
+     * @return array
+     */
+    protected function normalize(array $values, int $depth = 0): array
+    {
+        $normalized = [];
+        $max = isset($this->config['logs']['max_context_keys'])
+            ? (int) $this->config['logs']['max_context_keys']
+            : 50;
+
+        foreach ($values as $key => $value) {
+            if (count($normalized) >= $max) {
+                $normalized['_truncated'] = true;
+                break;
+            }
+
+            $normalized[$key] = $this->normalizeValue($value, $depth);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param mixed $value
+     * @param int $depth
+     * @return mixed
+     */
+    protected function normalizeValue($value, int $depth)
+    {
+        if (is_scalar($value) || $value === null) {
+            return is_string($value) ? $this->truncate($value) : $value;
+        }
+
+        if ($depth >= 3) {
+            return is_array($value) ? '[array]' : '[object]';
+        }
+
+        if (is_array($value)) {
+            return $this->normalize($value, $depth + 1);
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DateTimeInterface::ATOM);
+        }
+
+        if ($value instanceof Throwable) {
+            return [
+                'class' => get_class($value),
+                'message' => $this->truncate($value->getMessage()),
+                'file' => $value->getFile().':'.$value->getLine(),
+            ];
+        }
+
+        if ($value instanceof JsonSerializable) {
+            $data = $value->jsonSerialize();
+
+            return is_array($data) ? $this->normalize($data, $depth + 1) : $this->normalizeValue($data, $depth + 1);
+        }
+
+        if (is_object($value) && method_exists($value, 'toArray')) {
+            try {
+                return $this->normalize((array) $value->toArray(), $depth + 1);
+            } catch (Throwable $e) {
+                return get_class($value);
+            }
+        }
+
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return $this->truncate((string) $value);
+        }
+
+        return is_object($value) ? get_class($value) : '[resource]';
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    protected function truncate(string $value): string
+    {
+        $limit = 2000;
+
+        return strlen($value) > $limit ? substr($value, 0, $limit).'…' : $value;
+    }
+
+    /**
+     * @param array|\ArrayAccess $record
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    protected function value($record, string $key, $default = null)
+    {
+        if (is_array($record)) {
+            return array_key_exists($key, $record) ? $record[$key] : $default;
+        }
+
+        if ($record instanceof \ArrayAccess) {
+            return isset($record[$key]) ? $record[$key] : $default;
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param array|\ArrayAccess $record
+     * @param string $key
+     * @return array
+     */
+    protected function arrayValue($record, string $key): array
+    {
+        $value = $this->value($record, $key, []);
+
+        return is_array($value) ? $value : [];
+    }
+
+    public function close(): void
+    {
+        $this->buffer->flush();
+
+        parent::close();
+    }
+}

--- a/src/Logger/LogBuffer.php
+++ b/src/Logger/LogBuffer.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace LaraBug\Logger;
+
+use LaraBug\Http\Client;
+use Throwable;
+
+/**
+ * Buffers log records and ships them in batches.
+ *
+ * Mirrors Queue\EventBuffer, which solves the same problem for jobs: one HTTP
+ * request per log line would cost far more in network than the line is worth,
+ * and at log volume it would be the dominant cost in the request.
+ *
+ * Nothing in here may throw. Monolog rethrows whatever a handler throws, which
+ * would surface at the user's Log::info() call site and break their
+ * application, so every path out of this class swallows.
+ */
+class LogBuffer
+{
+    /** @var Client */
+    protected $client;
+
+    /** @var array */
+    protected $config;
+
+    /** @var array */
+    protected $buffer = [];
+
+    /**
+     * Guards against logging while shipping logs.
+     *
+     * Monolog's own cycle detection is per Logger instance, so it does not help
+     * when our HTTP client, or anything it touches, logs to a different channel
+     * that reaches us again.
+     *
+     * @var bool
+     */
+    protected $sending = false;
+
+    public function __construct(Client $client, array $config)
+    {
+        $this->client = $client;
+        $this->config = $config;
+    }
+
+    /**
+     * @param array $record
+     */
+    public function add(array $record)
+    {
+        if ($this->sending) {
+            return;
+        }
+
+        $this->buffer[] = $record;
+
+        if (count($this->buffer) >= $this->batchSize()) {
+            $this->flush();
+        }
+    }
+
+    public function flush()
+    {
+        if (empty($this->buffer) || $this->sending) {
+            return;
+        }
+
+        $records = $this->buffer;
+        $this->buffer = [];
+
+        $this->send($records);
+    }
+
+    /**
+     * @param array $records
+     * @param int $attempt
+     */
+    protected function send(array $records, $attempt = 1)
+    {
+        $this->sending = true;
+
+        try {
+            $response = $this->client->report([
+                'type' => 'logs_batch',
+                'project' => $this->config['project_key'] ?? '',
+                'logs' => $records,
+                'count' => count($records),
+            ]);
+
+            $maxRetries = isset($this->config['logs']['max_retries'])
+                ? (int) $this->config['logs']['max_retries']
+                : 3;
+
+            if ($response && method_exists($response, 'getStatusCode')) {
+                $status = $response->getStatusCode();
+
+                // A disabled feature or a rejected project is a permanent no.
+                // Retrying it just spends the user's time on every request.
+                if ($status === 403 || $status === 402 || $status === 422) {
+                    $this->disable();
+
+                    return;
+                }
+
+                if ($status >= 500 && $attempt < $maxRetries) {
+                    usleep(100000 * $attempt);
+                    $this->sending = false;
+                    $this->send($records, $attempt + 1);
+
+                    return;
+                }
+            }
+        } catch (Throwable $e) {
+            // Dropped on purpose. Losing a batch of logs is strictly better than
+            // throwing inside a log call.
+        }
+
+        $this->sending = false;
+    }
+
+    /**
+     * Stop collecting for the rest of this process.
+     *
+     * The server has told us it does not want these, so the handler should stop
+     * asking rather than repeat the round trip on every request.
+     */
+    protected function disable()
+    {
+        $this->buffer = [];
+        $this->config['logs']['enabled'] = false;
+        $this->sending = false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function enabled()
+    {
+        return ! isset($this->config['logs']['enabled'])
+            || $this->config['logs']['enabled'];
+    }
+
+    /**
+     * @return int
+     */
+    protected function batchSize()
+    {
+        $size = isset($this->config['logs']['batch_size'])
+            ? (int) $this->config['logs']['batch_size']
+            : 50;
+
+        return $size > 0 ? $size : 50;
+    }
+
+    /**
+     * A hard ceiling on what one process may hold, so a long running worker or
+     * a command emitting thousands of lines cannot grow the buffer unbounded
+     * between flushes.
+     *
+     * @return int
+     */
+    public function bufferedCount()
+    {
+        return count($this->buffer);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -46,6 +46,18 @@ class ServiceProvider extends BaseServiceProvider
         // Create an alias to the larabug-js-client.blade.php include
         Blade::include('larabug::larabug-js-client', 'larabugJavaScriptClient');
 
+        // Define the channel so applications only have to name it in their
+        // stack, never copy a block into config/logging.php. An application
+        // that does define its own keeps it: theirs wins.
+        if (! config('logging.channels.larabug-logs')) {
+            config([
+                'logging.channels.larabug-logs' => [
+                    'driver' => 'larabug-logs',
+                    'level' => config('larabug.logs.level', 'info'),
+                ],
+            ]);
+        }
+
         // Send whatever is still buffered at the end of the request. Without
         // this a request that logs less than one batch ships nothing, which is
         // most requests. Monolog's own close() covers the CLI case.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -46,6 +46,15 @@ class ServiceProvider extends BaseServiceProvider
         // Create an alias to the larabug-js-client.blade.php include
         Blade::include('larabug::larabug-js-client', 'larabugJavaScriptClient');
 
+        // Send whatever is still buffered at the end of the request. Without
+        // this a request that logs less than one batch ships nothing, which is
+        // most requests. Monolog's own close() covers the CLI case.
+        $this->app->terminating(function () {
+            if ($this->app->resolved(\LaraBug\Logger\LogBuffer::class)) {
+                $this->app[\LaraBug\Logger\LogBuffer::class]->flush();
+            }
+        });
+
         // Register queue monitoring events
         if (config('larabug.jobs.track_jobs', true)) {
             $this->app['events']->subscribe(\LaraBug\Queue\JobEventSubscriber::class);
@@ -146,6 +155,15 @@ class ServiceProvider extends BaseServiceProvider
             return new LaraBug($app[\LaraBug\Http\Client::class]);
         });
 
+        // Log shipping buffer. Bound lazily, so an app that never adds the
+        // channel never builds one.
+        $this->app->singleton(\LaraBug\Logger\LogBuffer::class, function ($app) {
+            return new \LaraBug\Logger\LogBuffer(
+                $app[\LaraBug\Http\Client::class],
+                $app['config']->get('larabug', [])
+            );
+        });
+
         if ($this->app['log'] instanceof \Illuminate\Log\LogManager) {
             $this->app['log']->extend('larabug', function ($app, $config) {
                 $handler = new \LaraBug\Logger\LaraBugHandler(
@@ -153,6 +171,28 @@ class ServiceProvider extends BaseServiceProvider
                 );
 
                 return new Logger('larabug', [$handler]);
+            });
+
+            $this->app['log']->extend('larabug-logs', function ($app, $config) {
+                $larabug = $app['config']->get('larabug', []);
+
+                $handler = new \LaraBug\Logger\LaraBugLogHandler(
+                    $app[\LaraBug\Logger\LogBuffer::class],
+                    [
+                        'logs' => isset($larabug['logs']) ? $larabug['logs'] : [],
+                        'environment' => $app['config']->get('app.env', ''),
+                        'release' => isset($larabug['logs']['release']) ? $larabug['logs']['release'] : '',
+                    ],
+                    // The channel's own level wins, so a stack can ship warnings
+                    // to us while writing everything to disk.
+                    Logger::toMonologLevel(
+                        isset($config['level'])
+                            ? $config['level']
+                            : (isset($larabug['logs']['level']) ? $larabug['logs']['level'] : 'info')
+                    )
+                );
+
+                return new Logger('larabug-logs', [$handler]);
             });
         }
 

--- a/tests/LogShippingTest.php
+++ b/tests/LogShippingTest.php
@@ -21,8 +21,45 @@ class LogShippingTest extends TestCase
         $this->app->instance(Client::class, $this->client);
 
         $this->app['config']['larabug.project_key'] = 'project';
-        $this->app['config']['logging.channels.larabug-logs'] = ['driver' => 'larabug-logs'];
+
+        // Deliberately no logging.channels.larabug-logs here: the package
+        // defines the channel, and naming it is all an application should have
+        // to do.
         $this->app['config']['logging.default'] = 'larabug-logs';
+    }
+
+    /** @test */
+    public function it_defines_the_channel_without_any_logging_config()
+    {
+        $this->assertSame(
+            'larabug-logs',
+            $this->app['config']['logging.channels.larabug-logs.driver']
+        );
+
+        Log::info('Shipped through a channel nobody declared');
+
+        $this->buffer()->flush();
+
+        $this->client->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function an_application_defined_channel_wins()
+    {
+        $this->app['config']['logging.channels.larabug-logs'] = [
+            'driver' => 'larabug-logs',
+            'level' => 'warning',
+        ];
+
+        Log::info('Below the threshold');
+        Log::warning('At the threshold');
+
+        $this->buffer()->flush();
+
+        $logs = $this->client->requests()[0]['logs'];
+
+        $this->assertCount(1, $logs);
+        $this->assertSame('At the threshold', $logs[0]['message']);
     }
 
     /** @test */
@@ -45,22 +82,6 @@ class LogShippingTest extends TestCase
         $this->assertSame('First line', $payload['logs'][0]['message']);
         $this->assertSame('info', $payload['logs'][0]['level']);
         $this->assertSame('error', $payload['logs'][1]['level']);
-    }
-
-    /** @test */
-    public function it_respects_the_configured_level()
-    {
-        $this->app['config']['larabug.logs.level'] = 'warning';
-
-        Log::info('Below the threshold');
-        Log::warning('At the threshold');
-
-        $this->buffer()->flush();
-
-        $logs = $this->client->requests()[0]['logs'];
-
-        $this->assertCount(1, $logs);
-        $this->assertSame('At the threshold', $logs[0]['message']);
     }
 
     /** @test */

--- a/tests/LogShippingTest.php
+++ b/tests/LogShippingTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use Illuminate\Support\Facades\Log;
+use LaraBug\Http\Client;
+use LaraBug\Logger\LogBuffer;
+use LaraBug\Tests\Mocks\LaraBugClient;
+use RuntimeException;
+
+class LogShippingTest extends TestCase
+{
+    /** @var LaraBugClient */
+    protected $client;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = new LaraBugClient('login', 'project');
+        $this->app->instance(Client::class, $this->client);
+
+        $this->app['config']['larabug.project_key'] = 'project';
+        $this->app['config']['logging.channels.larabug-logs'] = ['driver' => 'larabug-logs'];
+        $this->app['config']['logging.default'] = 'larabug-logs';
+    }
+
+    /** @test */
+    public function it_ships_log_lines_as_a_batch()
+    {
+        Log::info('First line');
+        Log::error('Second line');
+
+        $this->client->assertRequestsSent(0);
+
+        $this->buffer()->flush();
+
+        $this->client->assertRequestsSent(1);
+
+        $payload = $this->client->requests()[0];
+
+        $this->assertSame('logs_batch', $payload['type']);
+        $this->assertSame('project', $payload['project']);
+        $this->assertSame(2, $payload['count']);
+        $this->assertSame('First line', $payload['logs'][0]['message']);
+        $this->assertSame('info', $payload['logs'][0]['level']);
+        $this->assertSame('error', $payload['logs'][1]['level']);
+    }
+
+    /** @test */
+    public function it_respects_the_configured_level()
+    {
+        $this->app['config']['larabug.logs.level'] = 'warning';
+
+        Log::info('Below the threshold');
+        Log::warning('At the threshold');
+
+        $this->buffer()->flush();
+
+        $logs = $this->client->requests()[0]['logs'];
+
+        $this->assertCount(1, $logs);
+        $this->assertSame('At the threshold', $logs[0]['message']);
+    }
+
+    /** @test */
+    public function it_sends_automatically_once_the_batch_is_full()
+    {
+        $this->app['config']['larabug.logs.batch_size'] = 2;
+
+        Log::info('One');
+        Log::info('Two');
+
+        $this->client->assertRequestsSent(1);
+    }
+
+    /** @test */
+    public function it_strips_the_exception_from_the_context()
+    {
+        // The Throwable is what LaraBugHandler reports separately, and left in
+        // place it would be the largest thing in the payload.
+        Log::error('Something broke', ['exception' => new RuntimeException('boom'), 'order' => 7]);
+
+        $this->buffer()->flush();
+
+        $context = $this->client->requests()[0]['logs'][0]['context'];
+
+        $this->assertArrayNotHasKey('exception', $context);
+        $this->assertSame(7, $context['order']);
+    }
+
+    /** @test */
+    public function it_carries_correlation_ids_from_the_context()
+    {
+        Log::info('Correlated', ['trace_id' => 'trace-1', 'user_identifier' => 'user-2']);
+
+        $this->buffer()->flush();
+
+        $log = $this->client->requests()[0]['logs'][0];
+
+        $this->assertSame('trace-1', $log['trace_id']);
+        $this->assertSame('user-2', $log['user_identifier']);
+    }
+
+    /** @test */
+    public function it_bounds_what_a_single_context_may_carry()
+    {
+        $this->app['config']['larabug.logs.max_context_keys'] = 2;
+
+        Log::info('Wide context', ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+
+        $this->buffer()->flush();
+
+        $context = $this->client->requests()[0]['logs'][0]['context'];
+
+        $this->assertSame([1, 2], [$context['a'], $context['b']]);
+        $this->assertArrayNotHasKey('c', $context);
+        $this->assertTrue($context['_truncated']);
+    }
+
+    /** @test */
+    public function it_sends_nothing_once_the_server_refuses_the_batch()
+    {
+        $this->app['config']['larabug.logs.enabled'] = false;
+
+        Log::info('Not going anywhere');
+
+        $this->buffer()->flush();
+
+        $this->client->assertRequestsSent(0);
+    }
+
+    /**
+     * @return LogBuffer
+     */
+    protected function buffer()
+    {
+        return $this->app[LogBuffer::class];
+    }
+}

--- a/tests/Mocks/LaraBugClient.php
+++ b/tests/Mocks/LaraBugClient.php
@@ -23,6 +23,14 @@ class LaraBugClient extends \LaraBug\Http\Client
     }
 
     /**
+     * @return array
+     */
+    public function requests()
+    {
+        return $this->requests;
+    }
+
+    /**
      * @param int $expectedCount
      */
     public function assertRequestsSent(int $expectedCount)


### PR DESCRIPTION
Adds a `larabug-logs` Monolog channel that buffers log lines and posts them to the existing `/api/log` endpoint with `type=logs_batch`, the same way queue jobs and CVE scans already travel. Adding the channel to the logging stack is the opt-in; the buffer flushes when it fills, on request terminate and on handler close.

The channel is defined in the package rather than copied into `config/logging.php`: applications name it in `LOG_STACK` and nothing else, and one that defines its own keeps it.

The exception object is stripped from context because LaraBugHandler reports it separately, and context values are bounded in depth and key count so a model in a log context cannot turn into an outage.