### PR TITLE
Report that this app's queue workers are alive

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -166,6 +166,55 @@ return [
     | Configure queue job monitoring behavior.
     |
     */
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Heartbeat
+    |--------------------------------------------------------------------------
+    |
+    | Everything else this package sends is a report about something that
+    | happened. None of it can tell a queue with no work from a queue with no
+    | workers, since both send nothing at all.
+    |
+    | The heartbeat is the one message that says a worker exists. It runs from
+    | the scheduler, so it needs `schedule:run` to be running; where Horizon is
+    | installed it also carries its supervisor status, process counts and the
+    | wait Horizon measures per queue.
+    |
+    */
+    'heartbeat' => [
+        /*
+        | Enable or disable the heartbeat
+        | Set to false via LB_HEARTBEAT=false to stop reporting worker state
+        | Default: true
+        */
+        'enabled' => env('LB_HEARTBEAT', true),
+
+        /*
+        | How often the heartbeat is scheduled
+        | One of: everyMinute, everyTwoMinutes, everyFiveMinutes, everyTenMinutes
+        | Anything longer and a stopped worker goes unnoticed for that long
+        | Default: everyMinute
+        */
+        'schedule' => env('LB_HEARTBEAT_SCHEDULE', 'everyMinute'),
+
+        /*
+        | Where the heartbeat is sent
+        | Left null it follows `server` above, which is what a self-hosted
+        | install wants; set it only when the two live apart
+        | Default: null
+        */
+        'server' => env('LB_HEARTBEAT_SERVER'),
+
+        /*
+        | Which queues to measure when Horizon is not installed
+        | Either names on the default connection, ['emails', 'default'], or
+        | pairs, [['connection' => 'redis', 'queue' => 'emails']]
+        | Left empty the default connection's own queue is used
+        | Default: []
+        */
+        'queues' => [],
+    ],
+
     'jobs' => [
         /*
         | Enable or disable queue job tracking

--- a/src/Commands/HeartbeatCommand.php
+++ b/src/Commands/HeartbeatCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LaraBug\Commands;
+
+use Illuminate\Console\Command;
+use LaraBug\Http\Client;
+use LaraBug\Queue\Heartbeat;
+
+class HeartbeatCommand extends Command
+{
+    protected $signature = 'larabug:heartbeat {--show : Print the payload instead of sending it}';
+
+    protected $description = 'Report that this app\'s queue workers are alive';
+
+    public function handle()
+    {
+        $payload = app(Heartbeat::class)->payload();
+
+        if ($this->option('show')) {
+            $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return 0;
+        }
+
+        if (! in_array(config('app.env'), (array) config('larabug.environments'), true)) {
+            $this->info('[LaraBug] Environment ('.config('app.env').') is not configured to report, nothing sent');
+
+            return 0;
+        }
+
+        $response = app(Client::class)->heartbeat($payload);
+
+        // A heartbeat is worth nothing if sending it can break the scheduler, so
+        // a failure is reported and swallowed. The panel's own view of a missing
+        // heartbeat is the same either way: nothing arrived.
+        if ($response === null) {
+            $this->error('✗ [LaraBug] Could not reach the server');
+
+            return 0;
+        }
+
+        $status = $response->getStatusCode();
+
+        if ($status >= 200 && $status < 300) {
+            $this->info('✓ [LaraBug] Heartbeat sent');
+
+            return 0;
+        }
+
+        $this->error('✗ [LaraBug] Server answered '.$status);
+
+        return 0;
+    }
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -63,6 +63,63 @@ class Client
     }
 
     /**
+     * Report that this app's workers are alive.
+     *
+     * Its own endpoint rather than a kind of report: this arrives on a schedule
+     * whether or not anything happened, and the thing it proves is that the
+     * sender is running at all.
+     *
+     * @param  array  $payload
+     * @return \Psr\Http\Message\ResponseInterface|null
+     */
+    public function heartbeat(array $payload)
+    {
+        try {
+            return $this->getGuzzleHttpClient()->request('POST', $this->heartbeatUrl(), [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$this->login,
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'LaraBug-Package',
+                ],
+                'json' => array_merge(['project' => $this->project], $payload),
+                'verify' => config('larabug.verify_ssl'),
+                // Shorter than a report's: this runs every minute from the
+                // scheduler, and a broker that has gone away should not hold the
+                // schedule open behind it.
+                'timeout' => 5,
+            ]);
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            return $e->getResponse();
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Follows the reporting server unless told otherwise, so a self-hosted
+     * install does not have to configure the same host twice.
+     *
+     * @return string
+     */
+    protected function heartbeatUrl(): string
+    {
+        $configured = config('larabug.heartbeat.server');
+
+        if ($configured) {
+            return $configured;
+        }
+
+        $server = (string) config('larabug.server');
+
+        if (substr($server, -8) === '/api/log') {
+            return substr($server, 0, -8).'/api/heartbeat';
+        }
+
+        return rtrim($server, '/').'/heartbeat';
+    }
+
+    /**
      * @return \GuzzleHttp\Client
      */
     public function getGuzzleHttpClient()

--- a/src/Queue/Heartbeat.php
+++ b/src/Queue/Heartbeat.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace LaraBug\Queue;
+
+use Illuminate\Support\Facades\Queue;
+
+/**
+ * A periodic "the workers are alive" report.
+ *
+ * Everything else this package sends is a report about something that happened:
+ * an exception, a job that ran. None of that can distinguish a queue with no
+ * work from a queue with no workers, because both send nothing at all. This is
+ * the one message that says a worker exists, which is why it is sent on a
+ * schedule rather than in response to anything.
+ *
+ * Where Horizon is installed it is asked directly, since it already knows its
+ * supervisors, their process counts and how long each queue has been waiting.
+ * Without it the queue driver is asked how much is waiting, which is less but
+ * is still measured rather than guessed.
+ */
+class Heartbeat
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function payload(): array
+    {
+        return [
+            'reported_at' => now()->toIso8601String(),
+            'environment' => config('app.env'),
+            'horizon' => $this->horizon(),
+            'queues' => $this->queues(),
+        ];
+    }
+
+    /**
+     * What Horizon says about itself, or that it is not here.
+     *
+     * Every repository call is guarded: Horizon can be installed and its Redis
+     * connection be down, and a heartbeat that throws is a heartbeat that never
+     * arrives, which the panel would read as the workers being gone.
+     *
+     * @return array<string, mixed>
+     */
+    protected function horizon(): array
+    {
+        if (! class_exists('\Laravel\Horizon\Horizon')) {
+            return ['installed' => false];
+        }
+
+        $report = [
+            'installed' => true,
+            'status' => null,
+            'masters' => 0,
+            'supervisors' => 0,
+            'processes' => 0,
+        ];
+
+        try {
+            $masters = app('\Laravel\Horizon\Contracts\MasterSupervisorRepository')->all();
+
+            $report['masters'] = count($masters);
+
+            // Horizon reports per master. One paused master is the whole thing
+            // paused as far as a queue is concerned, so the least healthy status
+            // wins rather than the first one read.
+            foreach ($masters as $master) {
+                $status = isset($master->status) ? $master->status : null;
+
+                if ($report['status'] === null || $status === 'paused') {
+                    $report['status'] = $status;
+                }
+            }
+
+            if ($report['masters'] === 0) {
+                $report['status'] = 'inactive';
+            }
+        } catch (\Throwable $e) {
+            $report['status'] = 'unknown';
+        }
+
+        try {
+            $supervisors = app('\Laravel\Horizon\Contracts\SupervisorRepository')->all();
+
+            $report['supervisors'] = count($supervisors);
+
+            foreach ($supervisors as $supervisor) {
+                $processes = isset($supervisor->processes) ? (array) $supervisor->processes : [];
+
+                $report['processes'] += array_sum($processes);
+
+                $options = isset($supervisor->options) ? (array) $supervisor->options : [];
+
+                // The two figures Horizon's own overview shows as "default" when
+                // the supervisor has not been given them.
+                $report['supervisor_options'][] = [
+                    'name' => isset($supervisor->name) ? $supervisor->name : null,
+                    'max_processes' => isset($options['maxProcesses']) ? $options['maxProcesses'] : null,
+                    'max_runtime' => isset($options['maxTime']) ? $options['maxTime'] : null,
+                    'max_throughput' => isset($options['maxJobs']) ? $options['maxJobs'] : null,
+                    'balance' => isset($options['balance']) ? $options['balance'] : null,
+                ];
+            }
+        } catch (\Throwable $e) {
+            // Leave the counts at zero: the master status above is the part that
+            // says whether anything is running.
+        }
+
+        return $report;
+    }
+
+    /**
+     * How much is waiting on each queue, and how long it has been waiting.
+     *
+     * Horizon's workload already answers both per queue, including the wait it
+     * measures itself. Without Horizon only the depth is available, and the
+     * panel is left to work out the age from the jobs it has been sent.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function queues(): array
+    {
+        $fromHorizon = $this->horizonWorkload();
+
+        if ($fromHorizon !== null) {
+            return $fromHorizon;
+        }
+
+        $queues = [];
+
+        foreach ($this->configuredQueues() as $entry) {
+            $size = null;
+
+            try {
+                $size = Queue::connection($entry['connection'])->size($entry['queue']);
+            } catch (\Throwable $e) {
+                // A driver that cannot be counted, such as sync, or a broker
+                // that is unreachable. Reporting null says "not measured",
+                // which is not the same as reporting nothing waiting.
+            }
+
+            $queues[] = [
+                'connection' => $entry['connection'],
+                'queue' => $entry['queue'],
+                'size' => $size,
+                'wait' => null,
+                'processes' => null,
+            ];
+        }
+
+        return $queues;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>|null
+     */
+    protected function horizonWorkload(): ?array
+    {
+        if (! class_exists('\Laravel\Horizon\Horizon')) {
+            return null;
+        }
+
+        try {
+            $workload = app('\Laravel\Horizon\Contracts\WorkloadRepository')->get();
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        $queues = [];
+
+        foreach ($workload as $entry) {
+            $entry = (array) $entry;
+
+            $queues[] = [
+                // Horizon names a queue by the connection's queues joined with
+                // commas when a supervisor watches several; it is passed through
+                // as reported rather than split, since that string is what its
+                // own dashboard shows.
+                'connection' => isset($entry['connection']) ? $entry['connection'] : null,
+                'queue' => isset($entry['name']) ? $entry['name'] : null,
+                'size' => isset($entry['length']) ? (int) $entry['length'] : null,
+                // Seconds in Horizon, milliseconds everywhere in this payload.
+                'wait' => isset($entry['wait']) ? (int) round($entry['wait'] * 1000) : null,
+                'processes' => isset($entry['processes']) ? (int) $entry['processes'] : null,
+            ];
+        }
+
+        return $queues;
+    }
+
+    /**
+     * The queues to measure when there is no Horizon to ask.
+     *
+     * Configured explicitly, or the default connection's own queue, which is
+     * the one an app that has never thought about this is using.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function configuredQueues(): array
+    {
+        $configured = config('larabug.heartbeat.queues', []);
+
+        if (! empty($configured)) {
+            $queues = [];
+
+            foreach ($configured as $entry) {
+                if (is_string($entry)) {
+                    $queues[] = ['connection' => config('queue.default'), 'queue' => $entry];
+
+                    continue;
+                }
+
+                $queues[] = [
+                    'connection' => isset($entry['connection']) ? $entry['connection'] : config('queue.default'),
+                    'queue' => isset($entry['queue']) ? $entry['queue'] : 'default',
+                ];
+            }
+
+            return $queues;
+        }
+
+        $connection = config('queue.default');
+
+        return [[
+            'connection' => $connection,
+            'queue' => config('queue.connections.'.$connection.'.queue', 'default'),
+        ]];
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace LaraBug;
 
 use LaraBug\Queue\DispatchMacros;
 use Monolog\Logger;
+use LaraBug\Commands\HeartbeatCommand;
 use LaraBug\Commands\ScanCommand;
 use LaraBug\Commands\TestCommand;
 use Illuminate\Console\Scheduling\Schedule;
@@ -40,6 +41,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->commands([
             TestCommand::class,
             ScanCommand::class,
+            HeartbeatCommand::class,
         ]);
 
         // Map any routes
@@ -58,6 +60,22 @@ class ServiceProvider extends BaseServiceProvider
         // Register queue monitoring events
         if (config('larabug.jobs.track_jobs', true)) {
             $this->app['events']->subscribe(\LaraBug\Queue\JobEventSubscriber::class);
+        }
+
+        // The heartbeat only has a job to do where the scheduler runs, which is
+        // also the only place it can be registered from.
+        if (config('larabug.heartbeat.enabled', true)) {
+            $this->app->booted(function () {
+                $schedule = $this->app->make(Schedule::class);
+
+                $event = $schedule->command('larabug:heartbeat')
+                    ->withoutOverlapping()
+                    // Not onOneServer: each server runs its own workers, and a
+                    // heartbeat from one of them says nothing about the rest.
+                    ->runInBackground();
+
+                $this->applyHeartbeatCadence($event, config('larabug.heartbeat.schedule', 'everyMinute'));
+            });
         }
 
         // CVE triggers
@@ -89,6 +107,27 @@ class ServiceProvider extends BaseServiceProvider
                     }
                 });
             }
+        }
+    }
+
+    /**
+     * switch, not match, for the same reason applyCadence below uses one: this
+     * package still supports PHP 7.4, where a match expression will not parse.
+     */
+    protected function applyHeartbeatCadence($event, string $cadence): void
+    {
+        switch (strtolower($cadence)) {
+            case 'everytwominutes':
+                $event->everyTwoMinutes();
+                break;
+            case 'everyfiveminutes':
+                $event->everyFiveMinutes();
+                break;
+            case 'everytenminutes':
+                $event->everyTenMinutes();
+                break;
+            default:
+                $event->everyMinute();
         }
     }
 


### PR DESCRIPTION
Everything this package sends is a report about something that happened, and none of it can tell a queue with no work from a queue with no workers: both send nothing at all. A healthy queue with an empty backlog and a queue whose workers died an hour ago produce identical silence.

The heartbeat is the one message that says a worker exists. `larabug:heartbeat` runs from the scheduler, once a minute by default, and posts to `/api/heartbeat`, derived from `LB_SERVER` so a self-hosted install does not configure the host twice.

Where Horizon is installed it is asked directly, since it already knows its master's status, its supervisors, their process counts, the wait it measures per queue and the `maxProcesses`/`maxTime`/`maxJobs` its own overview prints as "default". Without it the queue driver is asked how deep each queue is.

Every Horizon call is guarded on its own: Horizon can be installed with its Redis unreachable, and a heartbeat that throws never arrives, which reads as the workers being gone. A queue whose depth cannot be counted reports null rather than nought.

Not `onOneServer()`, unlike the CVE scan: each server runs its own workers, so a heartbeat from one says nothing about the others.

Needs the receiving `/api/heartbeat` endpoint on the panel side before it does anything.