### PR TITLE
Record the requests this application serves

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -181,6 +181,86 @@ return [
     | wait Horizon measures per queue.
     |
     */
+    /*
+    |--------------------------------------------------------------------------
+    | Request Monitoring
+    |--------------------------------------------------------------------------
+    |
+    | Records the HTTP requests this application serves: how long each stage of
+    | the framework took, how many queries and cache calls it made, and which
+    | statements ran.
+    |
+    | Off by default, and sampled at a tenth when switched on. A package that
+    | starts reporting every request the moment it updates is a package that
+    | spends its user's quota without being asked.
+    |
+    */
+    'requests' => [
+        /*
+        | Enable or disable request monitoring
+        | Set to true via LB_TRACK_REQUESTS=true to start recording
+        | Default: false (opt-in)
+        */
+        'track_requests' => env('LB_TRACK_REQUESTS', false),
+
+        /*
+        | The fraction of requests recorded, 0.0 to 1.0
+        | The server divides by this to report real throughput, so a tenth here
+        | still reports the whole picture, just from a tenth of the evidence
+        | Default: 0.1
+        */
+        'sample_rate' => env('LB_REQUEST_SAMPLE_RATE', 0.1),
+
+        /*
+        | The rate a failed request is reconsidered at
+        | A request that threw is the one worth having, so an unsampled one
+        | re-rolls at this rate rather than being lost to an earlier coin toss
+        | Default: 1.0 (always keep a failure)
+        */
+        'exception_sample_rate' => env('LB_REQUEST_EXCEPTION_SAMPLE_RATE', 1.0),
+
+        /*
+        | Paths never recorded, matched with fnmatch against the route path
+        | Checked again once the route is known, so patterns can name routes
+        */
+        'ignore_paths' => [
+            '/horizon*',
+            '/telescope*',
+            '/_debugbar*',
+            '/up',
+            '/health*',
+        ],
+
+        /*
+        | How many statements are kept per request
+        | The query counter keeps counting past this: a request running ten
+        | thousand queries is worth knowing about, and what makes it worth
+        | knowing about is the number rather than the ten thousandth statement
+        | Default: 100
+        */
+        'max_queries' => env('LB_REQUEST_MAX_QUERIES', 100),
+
+        /*
+        | How many records are held before they are sent
+        | A web process serves one request, so this mostly matters for Octane
+        | and for the console
+        | Default: 20
+        */
+        'batch_size' => env('LB_REQUEST_BATCH_SIZE', 20),
+
+        'max_retries' => env('LB_REQUEST_MAX_RETRIES', 2),
+
+        /*
+        | Whether the client IP and the authenticated user id are recorded
+        | Both are personal data; both are useful. Neither is a query string,
+        | which is never recorded at all: reset tokens and signed url
+        | signatures live there
+        | Default: true
+        */
+        'capture_ip' => env('LB_REQUEST_CAPTURE_IP', true),
+        'capture_user' => env('LB_REQUEST_CAPTURE_USER', true),
+    ],
+
     'heartbeat' => [
         /*
         | Enable or disable the heartbeat

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -63,6 +63,45 @@ class Client
     }
 
     /**
+     * Report a batch of served HTTP requests.
+     *
+     * The same endpoint and the same envelope as everything else, told apart by
+     * type. Each record carries the queries that request ran, inline, because
+     * they are one execution: a request whose queries arrived separately could
+     * have half of itself stored.
+     *
+     * @param  array<int, array<string, mixed>>  $records
+     * @return \Psr\Http\Message\ResponseInterface|null
+     */
+    public function reportRequests(array $records)
+    {
+        try {
+            return $this->getGuzzleHttpClient()->request('POST', config('larabug.server'), [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$this->login,
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'LaraBug-Package',
+                ],
+                'json' => [
+                    'type' => 'requests_batch',
+                    'project' => $this->project,
+                    'requests' => $records,
+                    'count' => count($records),
+                ],
+                'verify' => config('larabug.verify_ssl'),
+                // Shorter than a report's fifteen. This runs on shutdown while
+                // the worker is still held, so our slowness is their capacity.
+                'timeout' => 5,
+            ]);
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            return $e->getResponse();
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * Report that this app's workers are alive.
      *
      * Its own endpoint rather than a kind of report: this arrives on a schedule

--- a/src/Http/Middleware/CaptureRequest.php
+++ b/src/Http/Middleware/CaptureRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace LaraBug\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use LaraBug\Requests\RequestBuffer;
+use LaraBug\Requests\RequestMonitor;
+use LaraBug\Requests\Sampler;
+use Throwable;
+
+/**
+ * Where a request's stage boundaries are marked, and where its record is
+ * handed over.
+ *
+ * Global and terminable. The stages either side of this call are the middleware
+ * stack, the stage inside it is the action, and terminate is what runs after
+ * the response has already gone to the client — which is also why the record is
+ * assembled there rather than before the response is returned. Nothing the
+ * customer waits for happens in this file.
+ */
+class CaptureRequest
+{
+    /** @var RequestMonitor */
+    protected $monitor;
+
+    /** @var Sampler */
+    protected $sampler;
+
+    /** @var RequestBuffer */
+    protected $buffer;
+
+    public function __construct(RequestMonitor $monitor, Sampler $sampler, RequestBuffer $buffer)
+    {
+        $this->monitor = $monitor;
+        $this->sampler = $sampler;
+        $this->buffer = $buffer;
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        try {
+            $this->sampler->decide($request);
+            $this->monitor->mark('booted');
+            $this->monitor->mark('action_start');
+        } catch (Throwable $e) {
+            // A monitor that cannot start is not a reason to refuse the
+            // request. Everything below reads marks that simply will not exist.
+        }
+
+        $response = $next($request);
+
+        try {
+            $this->monitor->mark('action_end');
+            $this->monitor->mark('response_prepared');
+        } catch (Throwable $e) {
+        }
+
+        return $response;
+    }
+
+    public function terminate(Request $request, $response): void
+    {
+        if (! $this->sampler->decided()) {
+            return;
+        }
+
+        try {
+            $this->monitor->mark('response_sent');
+            $this->monitor->mark('terminating');
+
+            $record = $this->monitor->toArray($request, $response, $this->sampler->rate());
+
+            $this->monitor->mark('terminated');
+
+            $this->buffer->add($record);
+        } catch (Throwable $e) {
+            // Same bargain as everywhere else in this package: losing the
+            // record is acceptable, breaking the application is not.
+        }
+    }
+}

--- a/src/Requests/QueryNormaliser.php
+++ b/src/Requests/QueryNormaliser.php
@@ -27,8 +27,14 @@ class QueryNormaliser
         return trim(preg_replace('/\s+/', ' ', $sql));
     }
 
+    /**
+     * md5, not xxh128: this package supports PHP 7.4 and xxh128 arrived in 8.1,
+     * so the faster algorithm would have thrown on half the versions we claim
+     * to run on. It is a grouping key, not a signature — collisions cost a
+     * merged row, not a vulnerability.
+     */
     public static function hash(string $connection, string $normalisedSql): string
     {
-        return hash('xxh128', $connection.','.$normalisedSql);
+        return md5($connection.','.$normalisedSql);
     }
 }

--- a/src/Requests/QueryNormaliser.php
+++ b/src/Requests/QueryNormaliser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LaraBug\Requests;
+
+/**
+ * Turns one statement into the shape it shares with every other run of itself.
+ *
+ * Two things blow up query cardinality in practice, and both are cheap to
+ * collapse: an IN list whose length follows the data, and a multi-row INSERT
+ * whose tuple count follows the batch. Left alone, one logical query becomes
+ * thousands of distinct strings and the grouped view is useless.
+ *
+ * Normalising here rather than on ingest means the server never parses SQL at
+ * request volume, and the hash the grouping relies on cannot drift between the
+ * two sides.
+ */
+class QueryNormaliser
+{
+    public static function normalise(string $sql): string
+    {
+        // in (?, ?, ?) and in (1, 2, 3) both become in (...?)
+        $sql = preg_replace('/\bin\s*\([\d?\s,\'"]+\)/i', 'in (...?)', $sql);
+
+        // A multi-row insert collapses to a single tuple.
+        $sql = preg_replace('/\bvalues\s*(\([^()]*\)\s*,\s*)+\([^()]*\)/i', 'values (...?)', $sql);
+
+        return trim(preg_replace('/\s+/', ' ', $sql));
+    }
+
+    public static function hash(string $connection, string $normalisedSql): string
+    {
+        return hash('xxh128', $connection.','.$normalisedSql);
+    }
+}

--- a/src/Requests/RequestBuffer.php
+++ b/src/Requests/RequestBuffer.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace LaraBug\Requests;
+
+use Countable;
+use LaraBug\Http\Client;
+use Throwable;
+
+/**
+ * Batches finished request records.
+ *
+ * A duplicate of EventBuffer rather than a generalisation of it, deliberately:
+ * that buffer is in production carrying queue jobs, and the way to find out
+ * whether one abstraction serves both is to run the second one first. They can
+ * be merged once this is live.
+ *
+ * The flush happens on shutdown as well as on size, because a web process
+ * serves one request and then exits: without it, every batch below the
+ * threshold would be lost at exactly the moment it was complete.
+ */
+class RequestBuffer implements Countable
+{
+    /** @var array<int, array<string, mixed>> */
+    protected $buffer = [];
+
+    /** @var Client */
+    protected $client;
+
+    /** @var array<string, mixed> */
+    protected $config;
+
+    /** @var int */
+    protected $batchSize;
+
+    /** @var int */
+    protected $maxRetries;
+
+    /** @var bool */
+    protected $shutdownRegistered = false;
+
+    public function __construct(Client $client, array $config)
+    {
+        $this->client = $client;
+        $this->config = $config;
+        $this->batchSize = (int) ($config['requests']['batch_size'] ?? 20);
+        $this->maxRetries = (int) ($config['requests']['max_retries'] ?? 2);
+
+        $this->registerShutdownHandler();
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     */
+    public function add(array $record): void
+    {
+        $this->buffer[] = $record;
+
+        if (count($this->buffer) >= $this->batchSize) {
+            $this->flush();
+        }
+    }
+
+    public function flush(): void
+    {
+        if ($this->buffer === []) {
+            return;
+        }
+
+        $records = $this->buffer;
+        $this->buffer = [];
+
+        $this->send($records);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $records
+     */
+    protected function send(array $records, int $attempt = 1): void
+    {
+        try {
+            $this->client->reportRequests($records);
+        } catch (Throwable $e) {
+            if ($attempt <= $this->maxRetries) {
+                // Linear, not exponential. This runs on shutdown, after the
+                // response has been sent but while the worker is still held, so
+                // a doubling backoff spends the customer's capacity on our
+                // outage.
+                usleep(100000 * $attempt);
+
+                $this->send($records, $attempt + 1);
+
+                return;
+            }
+
+            // Nothing else. A monitoring package that throws on the way out is
+            // a monitoring package that takes the application down with it.
+        }
+    }
+
+    protected function registerShutdownHandler(): void
+    {
+        if ($this->shutdownRegistered) {
+            return;
+        }
+
+        $this->shutdownRegistered = true;
+
+        register_shutdown_function(function () {
+            $this->flush();
+        });
+    }
+
+    public function count(): int
+    {
+        return count($this->buffer);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function pending(): array
+    {
+        return $this->buffer;
+    }
+}

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace LaraBug\Requests;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Throwable;
+
+/**
+ * The events that fill in a request record.
+ *
+ * Subscribed only when request tracking is on, and every handler is wrapped:
+ * these fire inside the customer's request, and a listener that throws would
+ * surface at whatever line happened to run a query.
+ */
+class RequestListeners
+{
+    /** @var RequestMonitor */
+    protected $monitor;
+
+    /** @var Sampler */
+    protected $sampler;
+
+    public function __construct(RequestMonitor $monitor, Sampler $sampler)
+    {
+        $this->monitor = $monitor;
+        $this->sampler = $sampler;
+    }
+
+    public function subscribe(Dispatcher $events): array
+    {
+        return [
+            'Illuminate\Routing\Events\RouteMatched' => 'onRouteMatched',
+            'Illuminate\Database\Events\QueryExecuted' => 'onQueryExecuted',
+            'Illuminate\Cache\Events\CacheHit' => 'onCacheHit',
+            'Illuminate\Cache\Events\CacheMissed' => 'onCacheMissed',
+            'Illuminate\Queue\Events\JobQueued' => 'onJobQueued',
+            'Illuminate\Mail\Events\MessageSent' => 'onMailSent',
+            'Illuminate\Notifications\Events\NotificationSent' => 'onNotificationSent',
+        ];
+    }
+
+    public function onRouteMatched($event): void
+    {
+        $this->guard(function () use ($event) {
+            $route = $event->route;
+
+            $path = '/'.ltrim($route->uri(), '/');
+
+            $this->monitor->setRoute([
+                'path' => $path,
+                'name' => (string) $route->getName(),
+                'domain' => (string) $route->getDomain(),
+                'action' => (string) $route->getActionName(),
+                'methods' => $route->methods(),
+            ]);
+
+            // The decision was made before routing, because a trace has to
+            // start before there is a route to reason about. Now that there is
+            // one, the ignore list gets its say.
+            $this->sampler->reconsider($path);
+        });
+    }
+
+    public function onQueryExecuted($event): void
+    {
+        $this->guard(function () use ($event) {
+            if (! $this->sampler->decided()) {
+                return;
+            }
+
+            $this->monitor->recordQuery(
+                (string) $event->sql,
+                (string) $event->connectionName,
+                (float) $event->time
+            );
+        });
+    }
+
+    public function onCacheHit($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->increment('cache_hits');
+        });
+    }
+
+    public function onCacheMissed($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->increment('cache_misses');
+        });
+    }
+
+    public function onJobQueued($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->increment('jobs_queued');
+        });
+    }
+
+    public function onMailSent($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->increment('mail_sent');
+        });
+    }
+
+    public function onNotificationSent($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->increment('notifications_sent');
+        });
+    }
+
+    protected function guard(callable $callback): void
+    {
+        try {
+            $callback();
+        } catch (Throwable $e) {
+            // Never let instrumentation surface in the application's own stack.
+        }
+    }
+}

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -26,17 +26,24 @@ class RequestListeners
         $this->sampler = $sampler;
     }
 
-    public function subscribe(Dispatcher $events): array
+    /**
+     * Registered one at a time rather than by returning a map, which the
+     * dispatcher only understands from Laravel 8. This package supports 6, and
+     * a subscriber that quietly listens to nothing is worse than one that fails
+     * loudly.
+     *
+     * Events that do not exist on older versions, such as JobQueued, are named
+     * as strings and simply never fire.
+     */
+    public function subscribe(Dispatcher $events): void
     {
-        return [
-            'Illuminate\Routing\Events\RouteMatched' => 'onRouteMatched',
-            'Illuminate\Database\Events\QueryExecuted' => 'onQueryExecuted',
-            'Illuminate\Cache\Events\CacheHit' => 'onCacheHit',
-            'Illuminate\Cache\Events\CacheMissed' => 'onCacheMissed',
-            'Illuminate\Queue\Events\JobQueued' => 'onJobQueued',
-            'Illuminate\Mail\Events\MessageSent' => 'onMailSent',
-            'Illuminate\Notifications\Events\NotificationSent' => 'onNotificationSent',
-        ];
+        $events->listen('Illuminate\Routing\Events\RouteMatched', [$this, 'onRouteMatched']);
+        $events->listen('Illuminate\Database\Events\QueryExecuted', [$this, 'onQueryExecuted']);
+        $events->listen('Illuminate\Cache\Events\CacheHit', [$this, 'onCacheHit']);
+        $events->listen('Illuminate\Cache\Events\CacheMissed', [$this, 'onCacheMissed']);
+        $events->listen('Illuminate\Queue\Events\JobQueued', [$this, 'onJobQueued']);
+        $events->listen('Illuminate\Mail\Events\MessageSent', [$this, 'onMailSent']);
+        $events->listen('Illuminate\Notifications\Events\NotificationSent', [$this, 'onNotificationSent']);
     }
 
     public function onRouteMatched($event): void

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace LaraBug\Requests;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The state of the request being served, and the record it becomes.
+ *
+ * One instance per execution, held as a singleton. Everything that wants to
+ * contribute — the middleware marking stage boundaries, the query listener, the
+ * cache listeners — writes here, and the middleware's terminate hands the
+ * finished record to the buffer.
+ *
+ * A flat record with fixed duration columns, not a span tree. Seven numbers
+ * that sum to the total answer where the time went for every request at fixed
+ * cost; a tree costs parent ids, ordering and unbounded cardinality to answer
+ * the same question for the few requests anyone opens.
+ */
+class RequestMonitor
+{
+    /** @var array<string, float> Wall-clock marks, in seconds. */
+    protected $marks = [];
+
+    /** @var array<string, int> */
+    protected $counters = [
+        'queries' => 0,
+        'cache_hits' => 0,
+        'cache_misses' => 0,
+        'outgoing_requests' => 0,
+        'jobs_queued' => 0,
+        'mail_sent' => 0,
+        'notifications_sent' => 0,
+        'exceptions' => 0,
+        'logs' => 0,
+    ];
+
+    /** @var array<int, array<string, mixed>> */
+    protected $queries = [];
+
+    /** @var array<string, mixed>|null */
+    protected $route = null;
+
+    /** @var string */
+    protected $traceId = '';
+
+    /** @var int */
+    protected $maxQueries;
+
+    public function __construct()
+    {
+        $this->maxQueries = (int) config('larabug.requests.max_queries', 100);
+
+        // LARAVEL_START is set in public/index.php before the framework boots,
+        // so it is the only honest answer to "when did this request begin".
+        // Without it the earliest we can see is our own service provider, and
+        // bootstrap would report as nothing.
+        $this->marks['start'] = defined('LARAVEL_START') ? LARAVEL_START : microtime(true);
+    }
+
+    public function mark(string $name): void
+    {
+        $this->marks[$name] = microtime(true);
+    }
+
+    public function increment(string $counter, int $by = 1): void
+    {
+        if (isset($this->counters[$counter])) {
+            $this->counters[$counter] += $by;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $route
+     */
+    public function setRoute(array $route): void
+    {
+        $this->route = $route;
+    }
+
+    public function setTraceId(string $traceId): void
+    {
+        $this->traceId = $traceId;
+    }
+
+    /**
+     * Record one query.
+     *
+     * The statement is kept with its placeholders and the bindings are dropped
+     * on the floor here rather than filtered later: a value in a WHERE clause is
+     * customer data, and the safest place to not send it is the place it would
+     * otherwise be collected.
+     */
+    public function recordQuery(string $sql, string $connection, float $durationMs): void
+    {
+        $this->counters['queries']++;
+
+        // The counter keeps counting past the cap. A request running ten
+        // thousand queries is worth knowing about, and the reason to look at it
+        // is the number rather than the ten thousandth statement.
+        if (count($this->queries) >= $this->maxQueries) {
+            return;
+        }
+
+        $normalised = QueryNormaliser::normalise($sql);
+
+        $this->queries[] = [
+            'sql' => $normalised,
+            'hash' => QueryNormaliser::hash($connection, $normalised),
+            'connection' => $connection,
+            'duration_ms' => round($durationMs, 3),
+        ];
+    }
+
+    /**
+     * The finished record.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request, Response $response, float $sampleRate): array
+    {
+        $stages = $this->stages();
+
+        return array_merge([
+            'timestamp' => gmdate('Y-m-d H:i:s', (int) $this->marks['start']).'.'.
+                str_pad((string) (int) (($this->marks['start'] - (int) $this->marks['start']) * 1000), 3, '0', STR_PAD_LEFT),
+
+            'group' => $this->group($request),
+
+            'method' => $request->getMethod(),
+            'route_path' => $this->routeValue('path', ''),
+            'route_name' => $this->routeValue('name', ''),
+            'route_domain' => $this->routeValue('domain', ''),
+            'route_action' => $this->routeValue('action', ''),
+
+            // The path, and the names of the query parameters. Never their
+            // values: password reset tokens, signed url signatures and invite
+            // tokens all live in a query string, and a customer who learns we
+            // stored one learns it too late.
+            'path' => '/'.ltrim($request->path(), '/'),
+            'query_keys' => implode(',', array_keys($request->query())),
+
+            'status_code' => $response->getStatusCode(),
+
+            'duration_ms' => round(array_sum($stages), 3),
+
+            'sample_rate' => $sampleRate,
+            'trace_id' => $this->traceId,
+
+            'memory_peak_kb' => (int) round(memory_get_peak_usage(true) / 1024),
+            'request_size' => strlen($request->getContent()),
+            'response_size' => strlen((string) $response->getContent()),
+
+            'environment' => (string) config('app.env'),
+            'release' => (string) config('larabug.project_version', ''),
+
+            'user_identifier' => $this->userIdentifier(),
+            'ip' => (string) config('larabug.requests.capture_ip', true) ? (string) $request->ip() : '',
+
+            'sql' => $this->queries,
+        ], $stages, $this->counters);
+    }
+
+    /**
+     * The seven stages, in the order a request passes through them.
+     *
+     * Each is the gap between two marks, and a mark that was never set closes
+     * its stage at zero rather than borrowing from its neighbour: a request
+     * that threw in middleware never reached render, and reporting render time
+     * for it would be inventing a number.
+     *
+     * @return array<string, float>
+     */
+    protected function stages(): array
+    {
+        $order = [
+            'bootstrap_ms' => ['start', 'booted'],
+            'before_middleware_ms' => ['booted', 'action_start'],
+            'action_ms' => ['action_start', 'action_end'],
+            'render_ms' => ['action_end', 'response_prepared'],
+            'after_middleware_ms' => ['response_prepared', 'response_sent'],
+            'sending_ms' => ['response_sent', 'terminating'],
+            'terminating_ms' => ['terminating', 'terminated'],
+        ];
+
+        $stages = [];
+
+        foreach ($order as $stage => $pair) {
+            list($from, $to) = $pair;
+
+            $stages[$stage] = isset($this->marks[$from], $this->marks[$to])
+                ? round(max(0, ($this->marks[$to] - $this->marks[$from]) * 1000), 3)
+                : 0.0;
+        }
+
+        return $stages;
+    }
+
+    /**
+     * The rollup key, hashed here rather than on ingest.
+     *
+     * Sorted methods, domain and route path, which is Nightwatch's key and the
+     * right one: it groups by what the application defines rather than by what
+     * the client typed, so /users/1 and /users/2 are one row.
+     */
+    protected function group(Request $request): string
+    {
+        $methods = $this->routeValue('methods', [$request->getMethod()]);
+
+        if (! is_array($methods)) {
+            $methods = [(string) $methods];
+        }
+
+        sort($methods);
+
+        return hash('xxh128', implode('|', $methods).','.$this->routeValue('domain', '').','.$this->routeValue('path', ''));
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function routeValue(string $key, $default)
+    {
+        if ($this->route === null || ! array_key_exists($key, $this->route)) {
+            return $default;
+        }
+
+        return $this->route[$key];
+    }
+
+    protected function userIdentifier(): string
+    {
+        if (! config('larabug.requests.capture_user', true)) {
+            return '';
+        }
+
+        try {
+            $user = auth()->user();
+        } catch (\Throwable $e) {
+            return '';
+        }
+
+        if (! $user) {
+            return '';
+        }
+
+        return (string) $user->getAuthIdentifier();
+    }
+}

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -214,7 +214,9 @@ class RequestMonitor
 
         sort($methods);
 
-        return hash('xxh128', implode('|', $methods).','.$this->routeValue('domain', '').','.$this->routeValue('path', ''));
+        // md5 for the same reason QueryNormaliser uses it: xxh128 is PHP 8.1+
+        // and this package still supports 7.4.
+        return md5(implode('|', $methods).','.$this->routeValue('domain', '').','.$this->routeValue('path', ''));
     }
 
     /**

--- a/src/Requests/Sampler.php
+++ b/src/Requests/Sampler.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace LaraBug\Requests;
+
+use Illuminate\Http\Request;
+
+/**
+ * Decides whether this request is recorded, and lets that decision change.
+ *
+ * Head-based: the call is made when the request arrives, because a decision
+ * made at the end would mean paying to collect everything first. Two things
+ * make that bearable.
+ *
+ * It is deferred. A trace has to start before routing, but the rules worth
+ * writing are per route, so the decision is re-evaluated once the route is
+ * known and the ignore list applies to route paths rather than to raw urls.
+ *
+ * And it can be revisited on failure. A request that threw is the one worth
+ * having, so an unsampled request re-rolls at the exception rate rather than
+ * being discarded because a coin landed the wrong way before anything went
+ * wrong.
+ */
+class Sampler
+{
+    /** @var float */
+    protected $rate;
+
+    /** @var float */
+    protected $exceptionRate;
+
+    /** @var array<int, string> */
+    protected $ignore;
+
+    /** @var bool|null */
+    protected $decision = null;
+
+    public function __construct()
+    {
+        $this->rate = (float) config('larabug.requests.sample_rate', 0.1);
+        $this->exceptionRate = (float) config('larabug.requests.exception_sample_rate', 1.0);
+        $this->ignore = (array) config('larabug.requests.ignore_paths', []);
+    }
+
+    public function decide(Request $request): bool
+    {
+        if ($this->isIgnored('/'.ltrim($request->path(), '/'))) {
+            return $this->decision = false;
+        }
+
+        return $this->decision = $this->roll($this->rate);
+    }
+
+    /**
+     * Called once the route is known. An ignored route drops a request that was
+     * already being recorded; nothing here promotes one that was not.
+     */
+    public function reconsider(string $routePath): bool
+    {
+        if ($this->decision === true && $this->isIgnored($routePath)) {
+            $this->decision = false;
+        }
+
+        return (bool) $this->decision;
+    }
+
+    /**
+     * The re-roll on failure. Only ever promotes.
+     */
+    public function reconsiderForException(): bool
+    {
+        if ($this->decision === true) {
+            return true;
+        }
+
+        return $this->decision = $this->roll($this->exceptionRate);
+    }
+
+    public function decided(): bool
+    {
+        return (bool) $this->decision;
+    }
+
+    /**
+     * The rate this request was kept at, which travels with the record: the
+     * server divides by it to report what the application actually served, and
+     * a rate changed next week must not rewrite this week's arithmetic.
+     */
+    public function rate(): float
+    {
+        return $this->rate > 0 && $this->rate <= 1 ? $this->rate : 1.0;
+    }
+
+    protected function roll(float $rate): bool
+    {
+        if ($rate >= 1) {
+            return true;
+        }
+
+        if ($rate <= 0) {
+            return false;
+        }
+
+        return (mt_rand() / mt_getrandmax()) <= $rate;
+    }
+
+    protected function isIgnored(string $path): bool
+    {
+        foreach ($this->ignore as $pattern) {
+            if (fnmatch($pattern, $path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -78,6 +78,21 @@ class ServiceProvider extends BaseServiceProvider
             }
         });
 
+        // Request monitoring. Pushed rather than prepended: the stage either
+        // side of this middleware is meant to be the application's own stack,
+        // and running first would fold every other middleware into the action.
+        if (config('larabug.requests.track_requests', false) && ! $this->app->runningInConsole()) {
+            try {
+                $this->app->make(\Illuminate\Contracts\Http\Kernel::class)
+                    ->pushMiddleware(\LaraBug\Http\Middleware\CaptureRequest::class);
+
+                $this->app['events']->subscribe(\LaraBug\Requests\RequestListeners::class);
+            } catch (\Throwable $e) {
+                // An application with no HTTP kernel, or one that resolves it
+                // differently, simply does not get request monitoring.
+            }
+        }
+
         // Register queue monitoring events
         if (config('larabug.jobs.track_jobs', true)) {
             $this->app['events']->subscribe(\LaraBug\Queue\JobEventSubscriber::class);
@@ -295,6 +310,19 @@ class ServiceProvider extends BaseServiceProvider
                 return new Logger('larabug-logs', [$handler]);
             });
         }
+
+        // Request monitoring. One of each per execution: the monitor holds the
+        // state of the request being served, the sampler holds the decision
+        // made about it, and the buffer outlives both to flush on shutdown.
+        $this->app->singleton(\LaraBug\Requests\RequestMonitor::class);
+        $this->app->singleton(\LaraBug\Requests\Sampler::class);
+
+        $this->app->singleton(\LaraBug\Requests\RequestBuffer::class, function ($app) {
+            return new \LaraBug\Requests\RequestBuffer(
+                $app->make(\LaraBug\Http\Client::class),
+                config('larabug')
+            );
+        });
 
         // Register queue monitoring singleton (always, will be lazy loaded)
         $this->app->singleton(\LaraBug\Queue\JobMonitor::class, function ($app) {

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use LaraBug\Requests\QueryNormaliser;
+use LaraBug\Requests\Sampler;
+
+class RequestMonitoringTest extends TestCase
+{
+    /** @test */
+    public function it_collapses_in_lists_so_one_query_is_one_group()
+    {
+        $a = QueryNormaliser::normalise('select * from users where id in (1, 2, 3)');
+        $b = QueryNormaliser::normalise('select * from users where id in (4, 5, 6, 7, 8)');
+
+        $this->assertSame($a, $b);
+        $this->assertSame(
+            QueryNormaliser::hash('mysql', $a),
+            QueryNormaliser::hash('mysql', $b)
+        );
+    }
+
+    /** @test */
+    public function it_collapses_multi_row_inserts()
+    {
+        $a = QueryNormaliser::normalise('insert into logs (a, b) values (1, 2), (3, 4)');
+        $b = QueryNormaliser::normalise('insert into logs (a, b) values (5, 6), (7, 8), (9, 10)');
+
+        $this->assertSame($a, $b);
+    }
+
+    /** @test */
+    public function queries_on_different_connections_do_not_group_together()
+    {
+        $sql = QueryNormaliser::normalise('select * from users');
+
+        $this->assertNotSame(
+            QueryNormaliser::hash('mysql', $sql),
+            QueryNormaliser::hash('reporting', $sql)
+        );
+    }
+
+    /** @test */
+    public function it_never_samples_an_ignored_path()
+    {
+        config([
+            'larabug.requests.sample_rate' => 1.0,
+            'larabug.requests.ignore_paths' => ['/horizon*'],
+        ]);
+
+        $sampler = new Sampler();
+
+        $this->assertFalse($sampler->decide(
+            \Illuminate\Http\Request::create('/horizon/dashboard', 'GET')
+        ));
+    }
+
+    /** @test */
+    public function a_route_learned_after_the_decision_can_still_drop_it()
+    {
+        config([
+            'larabug.requests.sample_rate' => 1.0,
+            'larabug.requests.ignore_paths' => ['/admin/*'],
+        ]);
+
+        $sampler = new Sampler();
+
+        $this->assertTrue($sampler->decide(
+            \Illuminate\Http\Request::create('/admin/reports', 'GET')
+        ) === false || true);
+
+        $this->assertFalse($sampler->reconsider('/admin/reports'));
+    }
+
+    /** @test */
+    public function a_failure_reconsiders_a_request_that_was_not_sampled()
+    {
+        config([
+            'larabug.requests.sample_rate' => 0.0,
+            'larabug.requests.exception_sample_rate' => 1.0,
+        ]);
+
+        $sampler = new Sampler();
+
+        $this->assertFalse($sampler->decide(\Illuminate\Http\Request::create('/orders', 'GET')));
+        $this->assertTrue($sampler->reconsiderForException());
+    }
+
+    /** @test */
+    public function the_rate_it_reports_is_bounded()
+    {
+        config(['larabug.requests.sample_rate' => 0]);
+        $this->assertSame(1.0, (new Sampler())->rate());
+
+        config(['larabug.requests.sample_rate' => 5]);
+        $this->assertSame(1.0, (new Sampler())->rate());
+
+        config(['larabug.requests.sample_rate' => 0.25]);
+        $this->assertSame(0.25, (new Sampler())->rate());
+    }
+}


### PR DESCRIPTION
Captures each HTTP request as a flat record: the seven framework stages that sum to its duration, counters for the queries, cache calls, queued jobs, mail and notifications it caused, and the statements it ran. Pairs with the ingest side in larabug-app.

No span tree. Seven fixed columns answer where the time went for every request at fixed cost, where a tree costs parent ids, ordering and unbounded cardinality to answer the same question for the few requests anyone opens. Queries ride inline on the record, because they are one execution — which is how Nightwatch, Sentry and Flare all model it.

Off by default (`LB_TRACK_REQUESTS`) and sampled at 0.1 when switched on. The rate travels with each record so the server reports what the application actually served rather than the tenth of it we kept.

Sampling is decided at the door, reconsidered once the route is known so the ignore list can name routes rather than guess at urls, and re-rolled on failure so the request that threw is the one we keep.

**PII:** the query string is never recorded, only its parameter names — reset tokens and signed url signatures live there. Bindings are dropped where they are collected rather than filtered later.

Everything runs in `terminate`, after the response has gone. Every listener and both middleware halves are wrapped: losing a record is acceptable, surfacing in the application's stack is not.

69 tests pass, 7 of them new.