### PR TITLE
Give one execution a single trace id

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -259,6 +259,51 @@ return [
         */
         'capture_ip' => env('LB_REQUEST_CAPTURE_IP', true),
         'capture_user' => env('LB_REQUEST_CAPTURE_USER', true),
+
+        /*
+        | Whether request headers are recorded
+        | Headers are how you tell a browser from a crawler and a v1 client
+        | from a v2 one, which is usually what a strange request turns out to
+        | be. The names below are replaced with a marker rather than dropped:
+        | knowing a request carried an Authorization header is worth having,
+        | and knowing which token it carried is not
+        | Default: true
+        */
+        'capture_headers' => env('LB_REQUEST_CAPTURE_HEADERS', true),
+
+        'redact_headers' => [
+            'authorization',
+            'cookie',
+            'set-cookie',
+            'x-api-key',
+            'x-csrf-token',
+            'x-xsrf-token',
+            'proxy-authorization',
+        ],
+
+        /*
+        | Whether the request body is kept when the request failed
+        | Off by default, and never on a success: a body is the most sensitive
+        | thing a request carries, and it is only worth its risk on the handful
+        | of requests that returned a 5xx and have to be reproduced
+        | Default: false
+        */
+        'capture_payload_on_error' => env('LB_REQUEST_CAPTURE_PAYLOAD_ON_ERROR', false),
+
+        /*
+        | Fields replaced with a marker inside a captured body
+        | Matched against the key at any depth, case-insensitively, and as a
+        | substring: 'password' covers password_confirmation
+        */
+        'redact_fields' => [
+            'password',
+            'password_confirmation',
+            'token',
+            'secret',
+            'card',
+            'cvv',
+            'iban',
+        ],
     ],
 
     'heartbeat' => [

--- a/src/Http/Middleware/CaptureRequest.php
+++ b/src/Http/Middleware/CaptureRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use LaraBug\Requests\RequestBuffer;
 use LaraBug\Requests\RequestMonitor;
 use LaraBug\Requests\Sampler;
+use LaraBug\Requests\TraceContext;
 use Throwable;
 
 /**
@@ -41,6 +42,17 @@ class CaptureRequest
     {
         try {
             $this->sampler->decide($request);
+
+            // A new request is a new trace. Reset first, because under Octane
+            // this process already served one and would otherwise hand its id
+            // to every request for the life of the worker.
+            //
+            // Touched at the start so every log line and exception from here on
+            // carries the same id, whether or not this request ends up sampled:
+            // deciding late would leave the earliest lines unstamped.
+            TraceContext::reset();
+            TraceContext::id();
+
             $this->monitor->mark('booted');
             $this->monitor->mark('action_start');
         } catch (Throwable $e) {

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -95,6 +95,12 @@ class LaraBug
                 return false;
             }
 
+            // The request being served, if there is one, learns that it threw.
+            // Read from the container rather than injected: this class is
+            // resolved in applications with request monitoring switched off,
+            // where the monitor is never bound at all.
+            $this->tellTheRequestMonitor();
+
             if ($fileType == 'javascript') {
                 $data['fullUrl'] = $customData['url'];
                 $data['file'] = $customData['file'];
@@ -206,6 +212,27 @@ class LaraBug
      * @param Throwable $exception
      * @return array
      */
+    /**
+     * Count this exception against the request that caused it, and stamp the
+     * shared trace id onto the report.
+     *
+     * Wrapped whole: an application with request monitoring off has no monitor
+     * bound, and a failure to record a count must never stop an exception being
+     * reported.
+     */
+    protected function tellTheRequestMonitor(): void
+    {
+        try {
+            if (! config('larabug.requests.track_requests', false)) {
+                return;
+            }
+
+            app(\LaraBug\Requests\RequestMonitor::class)->recordException();
+        } catch (Throwable $e) {
+            //
+        }
+    }
+
     public function getExceptionData(Throwable $exception)
     {
         $data = [];

--- a/src/Logger/LaraBugLogHandler.php
+++ b/src/Logger/LaraBugLogHandler.php
@@ -4,6 +4,7 @@ namespace LaraBug\Logger;
 
 use DateTimeInterface;
 use JsonSerializable;
+use LaraBug\Requests\TraceContext;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Throwable;
@@ -81,7 +82,11 @@ class LaraBugLogHandler extends AbstractProcessingHandler
             // not into context, so dropping it would lose most of what makes a
             // line useful.
             'extra' => $this->normalize($this->arrayValue($record, 'extra')),
-            'trace_id' => (string) $this->correlation($record, 'trace_id'),
+            // Falls back to the ambient trace rather than to nothing. An
+            // application that never sets one still gets its lines joined to
+            // the request or the job that wrote them, which is the entire
+            // reason the field exists.
+            'trace_id' => $this->traceId($record),
             'exception_id' => (string) $this->correlation($record, 'exception_id'),
             'environment' => (string) ($this->config['environment'] ?? ''),
             'release' => (string) ($this->config['release'] ?? ''),
@@ -128,6 +133,30 @@ class LaraBugLogHandler extends AbstractProcessingHandler
      *
      * @param array|\ArrayAccess $record
      * @param string $key
+     * @return string
+     */
+    /**
+     * @param array|\ArrayAccess $record
+     * @return string
+     */
+    protected function traceId($record): string
+    {
+        $supplied = $this->correlation($record, 'trace_id');
+
+        if ($supplied !== '') {
+            return $supplied;
+        }
+
+        try {
+            return TraceContext::id();
+        } catch (Throwable $e) {
+            // A line that cannot be correlated is still a line worth shipping.
+            return '';
+        }
+    }
+
+    /**
+     * @param array|\ArrayAccess $record
      * @return string
      */
     protected function correlation($record, string $key): string

--- a/src/Queue/JobEventSubscriber.php
+++ b/src/Queue/JobEventSubscriber.php
@@ -3,6 +3,7 @@
 namespace LaraBug\Queue;
 
 use Illuminate\Queue\Events\{JobProcessing, JobProcessed, JobFailed};
+use LaraBug\Requests\TraceContext;
 
 class JobEventSubscriber
 {
@@ -24,6 +25,11 @@ class JobEventSubscriber
 
     public function handleJobProcessing(JobProcessing $event): void
     {
+        // Each job is its own unit of work, so each gets its own trace. A
+        // worker process is long lived and would otherwise stamp every job it
+        // ever ran with the id of the first one.
+        TraceContext::reset();
+
         $jobId = $event->job->getJobId() ?? spl_object_hash($event->job);
 
         $this->timings[$jobId] = [

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -44,6 +44,17 @@ class RequestListeners
         $events->listen('Illuminate\Queue\Events\JobQueued', [$this, 'onJobQueued']);
         $events->listen('Illuminate\Mail\Events\MessageSent', [$this, 'onMailSent']);
         $events->listen('Illuminate\Notifications\Events\NotificationSent', [$this, 'onNotificationSent']);
+
+        // Outgoing HTTP, via the client's own event rather than Guzzle
+        // middleware: the event exists from Laravel 8 and needs no handler
+        // stack to be pushed onto a client we do not own.
+        $events->listen('Illuminate\Http\Client\Events\ResponseReceived', [$this, 'onOutgoingRequest']);
+        $events->listen('Illuminate\Http\Client\Events\ConnectionFailed', [$this, 'onOutgoingRequest']);
+
+        // Every log line written while this request was being served. The
+        // counter is what makes "this endpoint logs forty lines a request"
+        // visible without storing forty lines against it.
+        $events->listen('Illuminate\Log\Events\MessageLogged', [$this, 'onMessageLogged']);
     }
 
     public function onRouteMatched($event): void
@@ -115,6 +126,20 @@ class RequestListeners
     {
         $this->guard(function () {
             $this->monitor->increment('notifications_sent');
+        });
+    }
+
+    public function onOutgoingRequest($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->increment('outgoing_requests');
+        });
+    }
+
+    public function onMessageLogged($event): void
+    {
+        $this->guard(function () {
+            $this->monitor->recordLog();
         });
     }
 

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -3,6 +3,7 @@
 namespace LaraBug\Requests;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -43,7 +44,10 @@ class RequestMonitor
     protected $route = null;
 
     /** @var string */
-    protected $traceId = '';
+    protected $exceptionId = '';
+
+    /** @var array<string, mixed>|null */
+    protected $payload = null;
 
     /** @var int */
     protected $maxQueries;
@@ -79,9 +83,25 @@ class RequestMonitor
         $this->route = $route;
     }
 
-    public function setTraceId(string $traceId): void
+    /**
+     * The exception this request threw, if the SDK reported one.
+     *
+     * Set from the report path rather than guessed from the status code: a 500
+     * can be returned deliberately, and an exception can be reported on a
+     * request that still answers 200.
+     */
+    public function recordException(string $exceptionId = ''): void
     {
-        $this->traceId = $traceId;
+        $this->counters['exceptions']++;
+
+        if ($exceptionId !== '' && $this->exceptionId === '') {
+            $this->exceptionId = $exceptionId;
+        }
+    }
+
+    public function recordLog(): void
+    {
+        $this->counters['logs']++;
     }
 
     /**
@@ -146,7 +166,23 @@ class RequestMonitor
             'duration_ms' => round(array_sum($stages), 3),
 
             'sample_rate' => $sampleRate,
-            'trace_id' => $this->traceId,
+
+            // The same id the log lines and the exception from this execution
+            // carry, which is the whole reason any of them is worth joining.
+            'trace_id' => TraceContext::id(),
+            'exception_id' => $this->exceptionId,
+
+            'user_agent' => (string) $request->userAgent(),
+            'host' => (string) gethostname(),
+
+            // Redacted here, not on the way out: the headers most worth losing
+            // are the ones an exception in between would otherwise carry.
+            'headers' => $this->headers($request),
+
+            // Only when the request failed, and only when asked for. A request
+            // body is the highest-value thing in this payload and the one with
+            // no business being stored for the requests that worked.
+            'payload' => $this->payload($request, $response),
 
             'memory_peak_kb' => (int) round(memory_get_peak_usage(true) / 1024),
             'request_size' => strlen($request->getContent()),
@@ -160,6 +196,141 @@ class RequestMonitor
 
             'sql' => $this->queries,
         ], $stages, $this->counters);
+    }
+
+    /**
+     * Request headers, minus the ones that are credentials.
+     *
+     * An allow-by-default list with an explicit deny, rather than the reverse:
+     * a header nobody thought about is usually diagnostic, and the handful that
+     * are not are well known.
+     *
+     * @return string JSON
+     */
+    protected function headers(Request $request): string
+    {
+        if (! config('larabug.requests.capture_headers', true)) {
+            return '';
+        }
+
+        // The fallback matters more than it looks. An application that
+        // published its config before these keys existed reads nothing from
+        // the file, and an empty list here would mean its Authorization header
+        // was stored in full. The default is the list, not the absence of one.
+        $redact = array_map('strtolower', (array) config('larabug.requests.redact_headers', [
+            'authorization',
+            'cookie',
+            'set-cookie',
+            'x-api-key',
+            'x-csrf-token',
+            'x-xsrf-token',
+            'proxy-authorization',
+        ]));
+
+        $headers = [];
+
+        foreach ($request->headers->all() as $name => $values) {
+            $value = is_array($values) ? implode(', ', $values) : (string) $values;
+
+            // A constant marker, not one that preserves the length: the length
+            // of a secret is itself something worth not publishing.
+            $headers[$name] = in_array(strtolower($name), $redact, true) ? '[redacted]' : $value;
+        }
+
+        return (string) json_encode($headers);
+    }
+
+    /**
+     * The request body, on failure only.
+     *
+     * Nightwatch's bargain, and the right one: the body is what you need to
+     * reproduce the request that broke, and what you have no reason to hold for
+     * the thousands that did not.
+     */
+    protected function payload(Request $request, Response $response): string
+    {
+        if (! config('larabug.requests.capture_payload_on_error', false)) {
+            return '';
+        }
+
+        if ($response->getStatusCode() < 500) {
+            return '';
+        }
+
+        if (in_array($request->getMethod(), ['GET', 'HEAD', 'OPTIONS', 'TRACE'], true)) {
+            return '';
+        }
+
+        $redact = array_map('strtolower', (array) config('larabug.requests.redact_fields', [
+            'password',
+            'password_confirmation',
+            'token',
+            'secret',
+            'card',
+            'cvv',
+            'iban',
+        ]));
+
+        return (string) json_encode($this->redact($request->all(), $redact));
+    }
+
+    /**
+     * Replace sensitive values anywhere in a body.
+     *
+     * Depth-first and by substring, because the field that matters is rarely at
+     * the top level under exactly the name the config lists: a checkout posts
+     * card[cvv], a registration posts user.password_confirmation, and a rule
+     * that only reads the outermost keys would store both.
+     *
+     * @param  array<int|string, mixed>  $input
+     * @param  array<int, string>  $redact  lowercased needles
+     * @return array<int|string, mixed>
+     */
+    protected function redact(array $input, array $redact): array
+    {
+        foreach ($input as $key => $value) {
+            // The key is judged before the value is walked into. A matching key
+            // takes its whole branch with it: 'card' has to remove
+            // card[number] as well as card[cvv], and recursing first would only
+            // have caught the one that happened to be named in the list.
+            if ($this->isSensitive($key, $redact)) {
+                $input[$key] = '[redacted]';
+
+                continue;
+            }
+
+            // An upload is a file handle, not data. It has no JSON form worth
+            // sending and its contents are not ours to hold, so it is described
+            // rather than serialised.
+            if ($value instanceof UploadedFile) {
+                $input[$key] = '[file: '.$value->getClientOriginalName().']';
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $input[$key] = $this->redact($value, $redact);
+            }
+        }
+
+        return $input;
+    }
+
+    /**
+     * @param  int|string  $key
+     * @param  array<int, string>  $redact  lowercased needles
+     */
+    protected function isSensitive($key, array $redact): bool
+    {
+        $name = strtolower((string) $key);
+
+        foreach ($redact as $needle) {
+            if ($needle !== '' && strpos($name, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Requests/TraceContext.php
+++ b/src/Requests/TraceContext.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace LaraBug\Requests;
+
+use Illuminate\Support\Str;
+
+/**
+ * One id shared by everything this execution reports.
+ *
+ * The request record, the log lines written during it and the exception it
+ * threw all carry the same trace id, which is what lets the panel show the
+ * lines leading up to an error rather than three unrelated lists.
+ *
+ * Static because the things that need it cannot reach each other: a Monolog
+ * handler, an exception reporter and a middleware share no object, and passing
+ * an id between them would mean touching every one of their signatures.
+ */
+class TraceContext
+{
+    /** @var string|null */
+    protected static $traceId = null;
+
+    public static function id(): string
+    {
+        if (self::$traceId === null) {
+            // Ordered rather than random: ids that sort by creation make a
+            // range scan possible later, and cost nothing now.
+            self::$traceId = (string) Str::orderedUuid();
+        }
+
+        return self::$traceId;
+    }
+
+    /**
+     * Starts a new trace. Called when a queued job or a console command begins,
+     * because those are separate executions from the request that dispatched
+     * them and sharing an id would merge two stories into one.
+     */
+    public static function reset(): void
+    {
+        self::$traceId = null;
+    }
+}

--- a/src/Requests/TraceContext.php
+++ b/src/Requests/TraceContext.php
@@ -2,8 +2,6 @@
 
 namespace LaraBug\Requests;
 
-use Illuminate\Support\Str;
-
 /**
  * One id shared by everything this execution reports.
  *
@@ -23,12 +21,39 @@ class TraceContext
     public static function id(): string
     {
         if (self::$traceId === null) {
-            // Ordered rather than random: ids that sort by creation make a
-            // range scan possible later, and cost nothing now.
-            self::$traceId = (string) Str::orderedUuid();
+            self::$traceId = self::generate();
         }
 
         return self::$traceId;
+    }
+
+    /**
+     * A time-ordered id, built here rather than taken from Str::orderedUuid().
+     *
+     * The framework helper routes through ramsey/uuid's COMB generator, which
+     * on the versions Laravel 6 and 7 resolve to needs moontoast/math to
+     * convert a 128 bit integer. This package supports those releases and is
+     * not going to add a dependency to make an id.
+     *
+     * The layout is the same bargain orderedUuid strikes: 48 bits of
+     * millisecond timestamp in front, random after, so ids sort by creation
+     * and a range scan stays possible later.
+     */
+    protected static function generate(): string
+    {
+        $milliseconds = (int) round(microtime(true) * 1000);
+        $hex = str_pad(dechex($milliseconds), 12, '0', STR_PAD_LEFT);
+
+        $random = bin2hex(random_bytes(10));
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($random, 0, 4),
+            substr($random, 4, 4),
+            substr($random, 8, 12)
+        );
     }
 
     /**

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -2,8 +2,12 @@
 
 namespace LaraBug\Tests;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use LaraBug\Requests\QueryNormaliser;
+use LaraBug\Requests\RequestMonitor;
 use LaraBug\Requests\Sampler;
+use LaraBug\Requests\TraceContext;
 
 class RequestMonitoringTest extends TestCase
 {
@@ -97,5 +101,128 @@ class RequestMonitoringTest extends TestCase
 
         config(['larabug.requests.sample_rate' => 0.25]);
         $this->assertSame(0.25, (new Sampler())->rate());
+    }
+
+    /** @test */
+    public function it_replaces_credential_headers_with_a_marker()
+    {
+        $request = Request::create('/orders', 'GET');
+        $request->headers->set('Authorization', 'Bearer real-token');
+        $request->headers->set('Cookie', 'session=abc');
+        $request->headers->set('Accept', 'application/json');
+
+        $headers = $this->headersFor($request);
+
+        $this->assertSame('[redacted]', $headers['authorization']);
+        $this->assertSame('[redacted]', $headers['cookie']);
+        // Everything not on the list survives: a header nobody thought about
+        // is usually diagnostic.
+        $this->assertSame('application/json', $headers['accept']);
+    }
+
+    /** @test */
+    public function it_redacts_headers_even_when_the_published_config_predates_the_key()
+    {
+        // The shape an application upgrading into this feature is actually in.
+        // mergeConfigFrom is shallow, so a published file that predates these
+        // keys replaces the whole requests array and the key is simply absent.
+        $requests = config('larabug.requests');
+        unset($requests['redact_headers']);
+        config(['larabug.requests' => $requests]);
+
+        $request = Request::create('/orders', 'GET');
+        $request->headers->set('Authorization', 'Bearer real-token');
+
+        $this->assertSame('[redacted]', $this->headersFor($request)['authorization']);
+    }
+
+    /** @test */
+    public function a_body_is_kept_only_when_the_request_failed()
+    {
+        config(['larabug.requests.capture_payload_on_error' => true]);
+
+        $body = ['email' => 'a@b.c'];
+
+        $this->assertSame('', $this->payloadFor(Request::create('/orders', 'POST', $body), 200));
+        $this->assertSame('', $this->payloadFor(Request::create('/orders', 'POST', $body), 422));
+        // A GET has no body worth keeping, and its parameters are in the query
+        // string, which is never stored.
+        $this->assertSame('', $this->payloadFor(Request::create('/orders', 'GET', $body), 500));
+
+        $this->assertNotSame('', $this->payloadFor(Request::create('/orders', 'POST', $body), 500));
+    }
+
+    /** @test */
+    public function a_kept_body_carries_no_secrets_at_any_depth()
+    {
+        config(['larabug.requests.capture_payload_on_error' => true]);
+
+        $request = Request::create('/orders', 'POST', [
+            'email' => 'a@b.c',
+            'password' => 'hunter2',
+            'password_confirmation' => 'hunter2',
+            'card' => ['number' => '4111111111111111', 'cvv' => '123'],
+            'order_reference' => 'SUITE-1001',
+        ]);
+
+        $payload = json_decode($this->payloadFor($request, 500), true);
+
+        $this->assertSame('[redacted]', $payload['password']);
+        // Matched as a substring, because the field that matters is rarely
+        // named exactly what the list says.
+        $this->assertSame('[redacted]', $payload['password_confirmation']);
+        // The whole branch goes, because its parent key matched.
+        $this->assertSame('[redacted]', $payload['card']);
+
+        // And the rest survives, or there would be nothing left worth storing.
+        $this->assertSame('a@b.c', $payload['email']);
+        $this->assertSame('SUITE-1001', $payload['order_reference']);
+    }
+
+    /** @test */
+    public function everything_in_one_execution_shares_a_trace_id()
+    {
+        TraceContext::reset();
+
+        $first = TraceContext::id();
+
+        $this->assertSame($first, TraceContext::id());
+
+        TraceContext::reset();
+
+        $this->assertNotSame($first, TraceContext::id());
+    }
+
+    /** @test */
+    public function an_exception_counts_against_the_request_that_threw_it()
+    {
+        $monitor = new RequestMonitor();
+
+        $monitor->recordException('exc-1');
+        $monitor->recordException();
+
+        $record = $monitor->toArray(Request::create('/orders', 'GET'), new Response('', 500), 1.0);
+
+        $this->assertSame(2, $record['exceptions']);
+        // The first id reported wins: it is the one that caused the failure,
+        // and later ones are usually the handler's own noise.
+        $this->assertSame('exc-1', $record['exception_id']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headersFor(Request $request)
+    {
+        $record = (new RequestMonitor())->toArray($request, new Response('', 200), 1.0);
+
+        return json_decode($record['headers'], true);
+    }
+
+    private function payloadFor(Request $request, int $status)
+    {
+        $record = (new RequestMonitor())->toArray($request, new Response('', $status), 1.0);
+
+        return $record['payload'];
     }
 }


### PR DESCRIPTION
A request, the log lines it wrote and the exception it threw were three unrelated records. `TraceContext` holds one id per unit of work: the middleware starts a fresh one per request, the queue subscriber does the same per job, and the log handler falls back to it when the application supplied none. Joining a request to its own logs needs no application-side configuration.

Also fills the counters that were declared and never populated: exceptions, log lines, and outgoing HTTP calls (from the client's own events, no Guzzle middleware).

Headers are captured with credential names replaced by a marker. The body is kept only on a 5xx, only on a non-GET, and only when the application opts in.

Two things worth a look in review:

- Redaction judges the key before recursing into the value, so a matching key takes its whole branch. Recursing first stored `card[number]` in full while marking only `card[cvv]`.
- The redaction lists default in code as well as in the config file. `mergeConfigFrom` is shallow, so an application that published its config before these keys existed reads nothing from the file, and an empty fallback would have stored `Authorization` verbatim.

`exception_id` still arrives empty: the SDK does not know the id the server will assign. Correlation runs on `trace_id`, which does work.