### PR TITLE
Keep a failed request that sampling dropped

### DIFF
--- a/src/Http/Middleware/CaptureRequest.php
+++ b/src/Http/Middleware/CaptureRequest.php
@@ -73,7 +73,15 @@ class CaptureRequest
 
     public function terminate(Request $request, $response): void
     {
-        if (! $this->sampler->decided()) {
+        // A failure that head sampling dropped is worth having anyway: re-roll
+        // it at the exception rate and keep it if it now lands. Only for a 5xx,
+        // and only when the monitor actually started this request, so a
+        // terminate after a handle that could not is left alone rather than
+        // buffering a record with no stages behind it.
+        if (! $this->sampler->decided()
+            && ! ($this->isServerError($response)
+                && $this->monitor->started()
+                && $this->sampler->reconsiderForException())) {
             return;
         }
 
@@ -81,7 +89,14 @@ class CaptureRequest
             $this->monitor->mark('response_sent');
             $this->monitor->mark('terminating');
 
-            $record = $this->monitor->toArray($request, $response, $this->sampler->rate());
+            // A 5xx carries its effective keep-rate, not the head rate: it is
+            // kept far more often than head sampling implies, so weighting it by
+            // the head rate would count each failure many times over.
+            $rate = $this->isServerError($response)
+                ? $this->sampler->rateForException()
+                : $this->sampler->rate();
+
+            $record = $this->monitor->toArray($request, $response, $rate);
 
             $this->monitor->mark('terminated');
 
@@ -90,5 +105,13 @@ class CaptureRequest
             // Same bargain as everywhere else in this package: losing the
             // record is acceptable, breaking the application is not.
         }
+    }
+
+    /**
+     * @param  mixed  $response
+     */
+    private function isServerError($response): bool
+    {
+        return method_exists($response, 'getStatusCode') && $response->getStatusCode() >= 500;
     }
 }

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -5,6 +5,7 @@ namespace LaraBug;
 use Throwable;
 use LaraBug\Http\Client;
 use LaraBug\Filters\DataFilter;
+use LaraBug\Requests\TraceContext;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
@@ -286,6 +287,13 @@ class LaraBug
 
         // Get project version
         $data['project_version'] = config('larabug.project_version', null);
+
+        // The trace this exception was thrown in. An exception thrown while
+        // serving a request carries that request's id (the middleware set it
+        // before routing), which is what lets the server join the failed
+        // request to the issue it caused. Outside a tracked request this is a
+        // fresh id that simply no request shares.
+        $data['trace_id'] = TraceContext::id();
 
         // Add custom context data
         if (!empty(self::$customContext)) {

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -68,6 +68,16 @@ class RequestMonitor
         $this->marks[$name] = microtime(true);
     }
 
+    /**
+     * Whether the middleware got as far as marking where the action began. A
+     * terminate that runs after a handle that could not started nothing worth
+     * recording, and has no failure to promote.
+     */
+    public function started(): bool
+    {
+        return isset($this->marks['action_start']);
+    }
+
     public function increment(string $counter, int $by = 1): void
     {
         if (isset($this->counters[$counter])) {

--- a/src/Requests/Sampler.php
+++ b/src/Requests/Sampler.php
@@ -90,6 +90,26 @@ class Sampler
         return $this->rate > 0 && $this->rate <= 1 ? $this->rate : 1.0;
     }
 
+    /**
+     * The rate a failed record travels with, which is not the head rate.
+     *
+     * A 5xx is kept far more often than head sampling implies: whatever the
+     * coin did on arrival, it re-rolls at the exception rate, so at the default
+     * 1.0 every failure is kept. Dividing by the head rate would then weight a
+     * failure by ten while it was really kept every time, counting ten failures
+     * where there was one and wrecking the error rate. Its true keep-chance is
+     * "head-sampled, or not and the exception re-roll kept it".
+     */
+    public function rateForException(): float
+    {
+        $head = $this->rate();
+        $exception = $this->exceptionRate > 0 && $this->exceptionRate <= 1 ? $this->exceptionRate : 1.0;
+
+        $effective = $head + (1 - $head) * $exception;
+
+        return $effective > 0 && $effective <= 1 ? $effective : 1.0;
+    }
+
     protected function roll(float $rate): bool
     {
         if ($rate >= 1) {

--- a/tests/LaraBugTest.php
+++ b/tests/LaraBugTest.php
@@ -144,7 +144,12 @@ class LaraBugTest extends TestCase
         $this->assertSame('http://localhost', $data['fullUrl']);
         $this->assertSame('it_can_get_formatted_exception_data', $data['exception']);
 
-        $this->assertCount(13, $data);
+        // The trace the exception was thrown in, so the server can join it to
+        // the request that failed.
+        $this->assertArrayHasKey('trace_id', $data);
+        $this->assertNotSame('', $data['trace_id']);
+
+        $this->assertCount(14, $data);
     }
 
     /** @test */

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -4,7 +4,9 @@ namespace LaraBug\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use LaraBug\Http\Middleware\CaptureRequest;
 use LaraBug\Requests\QueryNormaliser;
+use LaraBug\Requests\RequestBuffer;
 use LaraBug\Requests\RequestMonitor;
 use LaraBug\Requests\Sampler;
 use LaraBug\Requests\TraceContext;
@@ -207,6 +209,80 @@ class RequestMonitoringTest extends TestCase
         // The first id reported wins: it is the one that caused the failure,
         // and later ones are usually the handler's own noise.
         $this->assertSame('exc-1', $record['exception_id']);
+    }
+
+    /** @test */
+    public function a_failed_request_that_was_not_sampled_is_kept_at_the_exception_rate()
+    {
+        config([
+            'larabug.requests.sample_rate' => 0.0,
+            'larabug.requests.exception_sample_rate' => 1.0,
+        ]);
+
+        $this->assertCount(1, $this->recordsForFailedRequest());
+    }
+
+    /** @test */
+    public function a_failed_request_is_dropped_when_the_exception_rate_is_zero()
+    {
+        config([
+            'larabug.requests.sample_rate' => 0.0,
+            'larabug.requests.exception_sample_rate' => 0.0,
+        ]);
+
+        $this->assertCount(0, $this->recordsForFailedRequest());
+    }
+
+    /** @test */
+    public function a_kept_failure_carries_its_effective_rate_not_the_head_rate()
+    {
+        config([
+            'larabug.requests.sample_rate' => 0.1,
+            'larabug.requests.exception_sample_rate' => 1.0,
+        ]);
+
+        $records = $this->recordsForFailedRequest();
+
+        $this->assertCount(1, $records);
+        // Kept every time (0.1 + 0.9 * 1.0), so it weighs one and not ten.
+        $this->assertSame(1.0, $records[0]['sample_rate']);
+    }
+
+    /**
+     * Run a 500 through the middleware and return whatever it buffered.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function recordsForFailedRequest(): array
+    {
+        // A buffer that records rather than sends. It skips the parent
+        // constructor, so no shutdown flush is registered and no client is
+        // needed for a test that only cares whether the record was kept.
+        $buffer = new class extends RequestBuffer {
+            /** @var array<int, array<string, mixed>> */
+            public $records = [];
+
+            public function __construct()
+            {
+            }
+
+            public function add(array $record): void
+            {
+                $this->records[] = $record;
+            }
+        };
+
+        $middleware = new CaptureRequest(new RequestMonitor(), new Sampler(), $buffer);
+
+        $request = Request::create('/orders', 'GET');
+        $response = new Response('boom', 500);
+
+        $middleware->handle($request, function () use ($response) {
+            return $response;
+        });
+        $middleware->terminate($request, $response);
+
+        return $buffer->records;
     }
 
     /**


### PR DESCRIPTION
Wires `Sampler::reconsiderForException()` into `CaptureRequest::terminate`: a 5xx that head sampling dropped is re-rolled at `exception_sample_rate` (default 1.0, keep all) and buffered if it now keeps, guarded so a monitor that never started does nothing. So `exception_sample_rate` stops being a dead knob.

A kept failure carries its effective keep-rate (`Sampler::rateForException()`), not the head rate: it is kept far more often than head sampling implies, so weighting it by the head rate would count one failure as ten and wreck the error rate.

Part B of larabug-app #1220 phase 0 (#1221). Pairs with the larabug-app branch of the same name.