### PR TITLE
Capture each outbound HTTP call, not just the count

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -241,6 +241,15 @@ return [
         'max_queries' => env('LB_REQUEST_MAX_QUERIES', 100),
 
         /*
+        | How many outbound HTTP calls are kept per request
+        | The outgoing counter keeps counting past this, the same as queries: a
+        | request that fans out to a hundred services is worth knowing about, and
+        | the number is what says so
+        | Default: 50
+        */
+        'max_outgoing' => env('LB_REQUEST_MAX_OUTGOING', 50),
+
+        /*
         | How many records are held before they are sent
         | A web process serves one request, so this mostly matters for Octane
         | and for the console

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -131,9 +131,103 @@ class RequestListeners
 
     public function onOutgoingRequest($event): void
     {
-        $this->guard(function () {
-            $this->monitor->increment('outgoing_requests');
+        $this->guard(function () use ($event) {
+            $request = $event->request ?? null;
+
+            if ($request === null) {
+                return;
+            }
+
+            // ConnectionFailed carries no response: the call never completed.
+            $response = $event->response ?? null;
+            $failed = $response === null;
+
+            $url = (string) $request->url();
+
+            // recordOutgoing carries the counter, so a request that fans out
+            // past the cap is still counted while only the first calls are kept.
+            $this->monitor->recordOutgoing([
+                'method' => (string) $request->method(),
+                'host' => (string) parse_url($url, PHP_URL_HOST),
+                'url' => $this->strippedUrl($url),
+                'status_code' => $response ? (int) $response->status() : 0,
+                'duration_ms' => $this->outgoingDuration($response),
+                'failed' => $failed ? 1 : 0,
+                'error' => $this->outgoingError($event, $failed),
+            ]);
         });
+    }
+
+    /**
+     * The url with its query values stripped, the names kept, the same stance
+     * the request path takes. Rebuilt rather than regexed so a value carrying an
+     * & or = of its own cannot smuggle itself back in.
+     */
+    private function strippedUrl(string $url): string
+    {
+        $parts = parse_url($url);
+
+        if ($parts === false) {
+            return '';
+        }
+
+        $rebuilt = (isset($parts['scheme']) ? $parts['scheme'].'://' : '')
+            .($parts['host'] ?? '')
+            .(isset($parts['port']) ? ':'.$parts['port'] : '')
+            .($parts['path'] ?? '');
+
+        if (! isset($parts['query']) || $parts['query'] === '') {
+            return $rebuilt;
+        }
+
+        parse_str($parts['query'], $params);
+
+        $names = implode('&', array_map(function ($key) {
+            return $key.'=';
+        }, array_keys($params)));
+
+        return $names === '' ? $rebuilt : $rebuilt.'?'.$names;
+    }
+
+    /**
+     * The round trip in milliseconds, off Guzzle's transfer stats which the Http
+     * client hangs on the response. Zero when the call never got one.
+     *
+     * @param  mixed  $response
+     */
+    private function outgoingDuration($response): float
+    {
+        if ($response === null) {
+            return 0.0;
+        }
+
+        $stats = $response->transferStats ?? null;
+
+        if ($stats === null || ! method_exists($stats, 'getTransferTime') || $stats->getTransferTime() === null) {
+            return 0.0;
+        }
+
+        return round($stats->getTransferTime() * 1000, 3);
+    }
+
+    /**
+     * A short reason a call failed, for the ones that never got a response.
+     * ConnectionFailed grew an exception in later Laravel; older versions carry
+     * only the request, so a generic marker is the most that can be said.
+     *
+     * @param  mixed  $event
+     */
+    private function outgoingError($event, bool $failed): string
+    {
+        if (! $failed) {
+            return '';
+        }
+
+        if (isset($event->exception) && $event->exception instanceof \Throwable) {
+            return mb_substr($event->exception->getMessage(), 0, 255);
+        }
+
+        return 'Connection failed';
     }
 
     public function onMessageLogged($event): void

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -40,6 +40,9 @@ class RequestMonitor
     /** @var array<int, array<string, mixed>> */
     protected $queries = [];
 
+    /** @var array<int, array<string, mixed>> */
+    protected $outgoing = [];
+
     /** @var array<string, mixed>|null */
     protected $route = null;
 
@@ -52,9 +55,13 @@ class RequestMonitor
     /** @var int */
     protected $maxQueries;
 
+    /** @var int */
+    protected $maxOutgoing;
+
     public function __construct()
     {
         $this->maxQueries = (int) config('larabug.requests.max_queries', 100);
+        $this->maxOutgoing = (int) config('larabug.requests.max_outgoing', 50);
 
         // LARAVEL_START is set in public/index.php before the framework boots,
         // so it is the only honest answer to "when did this request begin".
@@ -144,6 +151,28 @@ class RequestMonitor
     }
 
     /**
+     * Record one outbound HTTP call.
+     *
+     * The counter keeps counting past the cap, the same as queries: a request
+     * that fans out to a hundred services is worth knowing about, and the number
+     * is what says so. The url arrives with its query values already stripped by
+     * the listener, the same stance the request path takes: a token in a
+     * callback url is customer data we have no business storing.
+     *
+     * @param  array<string, mixed>  $call
+     */
+    public function recordOutgoing(array $call): void
+    {
+        $this->counters['outgoing_requests']++;
+
+        if (count($this->outgoing) >= $this->maxOutgoing) {
+            return;
+        }
+
+        $this->outgoing[] = $call;
+    }
+
+    /**
      * The finished record.
      *
      * @return array<string, mixed>
@@ -205,6 +234,7 @@ class RequestMonitor
             'ip' => (string) config('larabug.requests.capture_ip', true) ? (string) $request->ip() : '',
 
             'sql' => $this->queries,
+            'outgoing' => $this->outgoing,
         ], $stages, $this->counters);
     }
 

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Response;
 use LaraBug\Http\Middleware\CaptureRequest;
 use LaraBug\Requests\QueryNormaliser;
 use LaraBug\Requests\RequestBuffer;
+use LaraBug\Requests\RequestListeners;
 use LaraBug\Requests\RequestMonitor;
 use LaraBug\Requests\Sampler;
 use LaraBug\Requests\TraceContext;
@@ -246,6 +247,90 @@ class RequestMonitoringTest extends TestCase
         $this->assertCount(1, $records);
         // Kept every time (0.1 + 0.9 * 1.0), so it weighs one and not ten.
         $this->assertSame(1.0, $records[0]['sample_rate']);
+    }
+
+    /** @test */
+    public function it_records_an_outgoing_call_with_its_query_values_stripped()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $listeners->onOutgoingRequest($this->outgoingEvent(
+            'GET',
+            'https://api.example.com/v1/users?token=secret&page=2',
+            new \Illuminate\Http\Client\Response(new \GuzzleHttp\Psr7\Response(200))
+        ));
+
+        $record = $monitor->toArray(Request::create('/orders', 'GET'), new Response('', 200), 1.0);
+
+        $this->assertSame(1, $record['outgoing_requests']);
+        $this->assertCount(1, $record['outgoing']);
+
+        $call = $record['outgoing'][0];
+        $this->assertSame('GET', $call['method']);
+        $this->assertSame('api.example.com', $call['host']);
+        $this->assertSame(200, $call['status_code']);
+        $this->assertSame(0, $call['failed']);
+        // The parameter names survive; a token in a callback url does not.
+        $this->assertSame('https://api.example.com/v1/users?token=&page=', $call['url']);
+    }
+
+    /** @test */
+    public function it_marks_an_outgoing_call_that_never_got_a_response()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        // No response: the ConnectionFailed shape.
+        $listeners->onOutgoingRequest($this->outgoingEvent('POST', 'https://down.example.com/hook', null));
+
+        $call = $monitor->toArray(Request::create('/orders', 'GET'), new Response('', 200), 1.0)['outgoing'][0];
+
+        $this->assertSame(1, $call['failed']);
+        $this->assertSame(0, $call['status_code']);
+        $this->assertNotSame('', $call['error']);
+    }
+
+    /** @test */
+    public function the_outgoing_counter_keeps_counting_past_the_cap()
+    {
+        config(['larabug.requests.max_outgoing' => 2]);
+
+        $monitor = new RequestMonitor();
+
+        for ($i = 0; $i < 5; $i++) {
+            $monitor->recordOutgoing([
+                'method' => 'GET', 'host' => 'x', 'url' => 'https://x',
+                'status_code' => 200, 'duration_ms' => 1.0, 'failed' => 0, 'error' => '',
+            ]);
+        }
+
+        $record = $monitor->toArray(Request::create('/orders', 'GET'), new Response('', 200), 1.0);
+
+        // All five counted, only two kept.
+        $this->assertSame(5, $record['outgoing_requests']);
+        $this->assertCount(2, $record['outgoing']);
+    }
+
+    /**
+     * A stand-in for an Http client event: the handler reads only ->request and
+     * ->response, so a plain object with those is enough and sidesteps the
+     * event constructors that changed shape between Laravel versions.
+     *
+     * @param  \Illuminate\Http\Client\Response|null  $response
+     */
+    private function outgoingEvent(string $method, string $url, $response): object
+    {
+        $event = new \stdClass();
+        $event->request = new \Illuminate\Http\Client\Request(
+            new \GuzzleHttp\Psr7\Request($method, $url)
+        );
+
+        if ($response !== null) {
+            $event->response = $response;
+        }
+
+        return $event;
     }
 
     /**

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -252,6 +252,10 @@ class RequestMonitoringTest extends TestCase
     /** @test */
     public function it_records_an_outgoing_call_with_its_query_values_stripped()
     {
+        if (! class_exists(\Illuminate\Http\Client\Request::class)) {
+            $this->markTestSkipped('The Http client and its ResponseReceived event are Laravel 7+.');
+        }
+
         $monitor = new RequestMonitor();
         $listeners = new RequestListeners($monitor, new Sampler());
 
@@ -278,6 +282,10 @@ class RequestMonitoringTest extends TestCase
     /** @test */
     public function it_marks_an_outgoing_call_that_never_got_a_response()
     {
+        if (! class_exists(\Illuminate\Http\Client\Request::class)) {
+            $this->markTestSkipped('The Http client and its ConnectionFailed event are Laravel 7+.');
+        }
+
         $monitor = new RequestMonitor();
         $listeners = new RequestListeners($monitor, new Sampler());
 


### PR DESCRIPTION
Phase 2 of larabug-app #1220 (#1223). The outgoing counter said how many calls a request made; this keeps the calls themselves. In onOutgoingRequest, alongside the count, record method, host, url (query values stripped, names kept), status, round trip, a failed flag for a call that never got a response, and a short error. Buffered on RequestMonitor, capped by a new max_outgoing (default 50, the counter keeps counting past it), emitted in toArray as an outgoing child array beside sql. The SDK's own reporting goes through Guzzle directly, so it never records itself. Pairs with larabug-app.