### PR TITLE
Capture each message a request sends or queues

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -250,6 +250,15 @@ return [
         'max_outgoing' => env('LB_REQUEST_MAX_OUTGOING', 50),
 
         /*
+        | How many messages are kept per request
+        | The mail counter keeps counting past this, the same as queries and
+        | outgoing calls: a request that fans a newsletter out to a hundred
+        | recipients is worth knowing about, and the number is what says so
+        | Default: 50
+        */
+        'max_mail' => env('LB_REQUEST_MAX_MAIL', 50),
+
+        /*
         | How many records are held before they are sent
         | A web process serves one request, so this mostly matters for Octane
         | and for the console
@@ -268,6 +277,16 @@ return [
         */
         'capture_ip' => env('LB_REQUEST_CAPTURE_IP', true),
         'capture_user' => env('LB_REQUEST_CAPTURE_USER', true),
+
+        /*
+        | Whether a sent message's full recipient addresses are recorded
+        | Off by default: the domains a request emailed are kept either way,
+        | which is the diagnostic part, and the addresses are personal data with
+        | no more business being stored than a query string's values. Turn this
+        | on only where the recipients are yours to keep
+        | Default: false
+        */
+        'capture_mail_recipients' => env('LB_REQUEST_CAPTURE_MAIL_RECIPIENTS', false),
 
         /*
         | Whether request headers are recorded

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -118,8 +118,18 @@ class RequestListeners
 
     public function onJobQueued($event): void
     {
-        $this->guard(function () {
+        $this->guard(function () use ($event) {
             $this->monitor->increment('jobs_queued');
+
+            // A queued mailable is a job whose payload is the mailable itself,
+            // and its send happens a worker away where no request is being
+            // recorded. Caught here, at dispatch, it is counted against the
+            // request that queued it or it is never seen inside one at all.
+            $job = $event->job ?? null;
+
+            if ($job instanceof \Illuminate\Mail\SendQueuedMailable) {
+                $this->recordQueuedMail($job->mailable ?? null);
+            }
         });
     }
 
@@ -299,6 +309,72 @@ class RequestListeners
         unset($this->mailStartedAt[$key]);
 
         return $duration;
+    }
+
+    /**
+     * Record a mailable that was queued rather than sent inline.
+     *
+     * Read off the mailable the job carries, not off a message: there is no
+     * message yet, the send is a worker away. Its recipients are already filled
+     * in by the time it is queued, so the counts and domains are known; the
+     * subject often is not, since an envelope resolves it at render, and the
+     * duration cannot be, so both are left for the send that is not ours to see.
+     *
+     * @param  mixed  $mailable
+     */
+    private function recordQueuedMail($mailable): void
+    {
+        if (! is_object($mailable)) {
+            return;
+        }
+
+        $to = $this->mailableAddresses($mailable, 'to');
+        $cc = $this->mailableAddresses($mailable, 'cc');
+        $bcc = $this->mailableAddresses($mailable, 'bcc');
+
+        $this->monitor->recordMail([
+            'mailable' => get_class($mailable),
+            'subject' => (string) ($mailable->subject ?? ''),
+            'to_count' => count($to),
+            'cc_count' => count($cc),
+            'bcc_count' => count($bcc),
+            'recipient_domains' => $this->mailRecipients(array_merge($to, $cc, $bcc)),
+            'queued' => 1,
+            'duration_ms' => 0.0,
+        ]);
+    }
+
+    /**
+     * The addresses in one of a mailable's recipient lists. A Mailable holds its
+     * to, cc and bcc as public arrays of ['name' => ..., 'address' => ...], which
+     * is a different shape from the message getters a sent message exposes.
+     *
+     * @param  mixed  $mailable
+     * @return array<int, string>
+     */
+    private function mailableAddresses($mailable, string $property): array
+    {
+        $recipients = $mailable->{$property} ?? [];
+
+        if (! is_array($recipients)) {
+            return [];
+        }
+
+        $addresses = [];
+
+        foreach ($recipients as $recipient) {
+            if (is_array($recipient) && isset($recipient['address'])) {
+                $addresses[] = (string) $recipient['address'];
+
+                continue;
+            }
+
+            if (is_string($recipient) && $recipient !== '') {
+                $addresses[] = $recipient;
+            }
+        }
+
+        return $addresses;
     }
 
     public function onNotificationSent($event): void

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -20,6 +20,9 @@ class RequestListeners
     /** @var Sampler */
     protected $sampler;
 
+    /** @var array<int, float> Send-start marks, in seconds, keyed by message. */
+    protected $mailStartedAt = [];
+
     public function __construct(RequestMonitor $monitor, Sampler $sampler)
     {
         $this->monitor = $monitor;
@@ -42,6 +45,11 @@ class RequestListeners
         $events->listen('Illuminate\Cache\Events\CacheHit', [$this, 'onCacheHit']);
         $events->listen('Illuminate\Cache\Events\CacheMissed', [$this, 'onCacheMissed']);
         $events->listen('Illuminate\Queue\Events\JobQueued', [$this, 'onJobQueued']);
+
+        // Paired: the sending event only starts a timer, the sent event is what
+        // records the message. A send that throws never reaches sent and leaves
+        // only a mark that the next send overwrites.
+        $events->listen('Illuminate\Mail\Events\MessageSending', [$this, 'onMailSending']);
         $events->listen('Illuminate\Mail\Events\MessageSent', [$this, 'onMailSent']);
         $events->listen('Illuminate\Notifications\Events\NotificationSent', [$this, 'onNotificationSent']);
 
@@ -115,11 +123,182 @@ class RequestListeners
         });
     }
 
+    public function onMailSending($event): void
+    {
+        $this->guard(function () use ($event) {
+            $message = $event->message ?? null;
+
+            if ($message === null) {
+                return;
+            }
+
+            $this->mailStartedAt[spl_object_id($message)] = microtime(true);
+        });
+    }
+
     public function onMailSent($event): void
     {
-        $this->guard(function () {
-            $this->monitor->increment('mail_sent');
+        $this->guard(function () use ($event) {
+            $message = $event->message ?? null;
+
+            if ($message === null) {
+                // A mailer that fired the event without a message still sent
+                // one; keep the tile honest even when there is nothing to detail.
+                $this->monitor->recordMail([]);
+
+                return;
+            }
+
+            $to = $this->mailAddresses($this->recipients($message, 'getTo'));
+            $cc = $this->mailAddresses($this->recipients($message, 'getCc'));
+            $bcc = $this->mailAddresses($this->recipients($message, 'getBcc'));
+
+            $this->monitor->recordMail([
+                'mailable' => $this->mailableClass(),
+                'subject' => $this->mailSubject($message),
+                'to_count' => count($to),
+                'cc_count' => count($cc),
+                'bcc_count' => count($bcc),
+                'recipient_domains' => $this->mailRecipients(array_merge($to, $cc, $bcc)),
+                'queued' => 0,
+                'duration_ms' => $this->mailDuration($message),
+            ]);
         });
+    }
+
+    /**
+     * The class of the mailable being sent, when there is one.
+     *
+     * Neither mail event carries it, so it is read off the call stack instead:
+     * a Mailable's send() is always a frame below the event that fires inside
+     * it. Empty for mail sent without a mailable — Mail::raw() and the like —
+     * where the subject is the only name a message has.
+     */
+    private function mailableClass(): string
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 50) as $frame) {
+            $object = $frame['object'] ?? null;
+
+            if ($object instanceof \Illuminate\Mail\Mailable) {
+                return get_class($object);
+            }
+        }
+
+        return '';
+    }
+
+    private function mailSubject($message): string
+    {
+        if (! method_exists($message, 'getSubject')) {
+            return '';
+        }
+
+        return (string) $message->getSubject();
+    }
+
+    /**
+     * One address list off a message, across mail engines. Symfony's Email has
+     * the getters and returns Address objects; the older Swift message had the
+     * same getter names and returned an [address => name] map. A version without
+     * the getter simply contributes nobody.
+     *
+     * @return array<int|string, mixed>
+     */
+    private function recipients($message, string $getter): array
+    {
+        if (! method_exists($message, $getter)) {
+            return [];
+        }
+
+        return (array) $message->{$getter}();
+    }
+
+    /**
+     * The address strings in a recipient list, whichever engine produced it.
+     * Symfony hands over Address objects; Swift keyed the address and put the
+     * name in the value.
+     *
+     * @param  array<int|string, mixed>  $recipients
+     * @return array<int, string>
+     */
+    private function mailAddresses(array $recipients): array
+    {
+        $addresses = [];
+
+        foreach ($recipients as $key => $value) {
+            if (is_object($value) && method_exists($value, 'getAddress')) {
+                $addresses[] = (string) $value->getAddress();
+
+                continue;
+            }
+
+            if (is_string($key) && $key !== '') {
+                $addresses[] = $key;
+
+                continue;
+            }
+
+            if (is_string($value) && $value !== '') {
+                $addresses[] = $value;
+            }
+        }
+
+        return $addresses;
+    }
+
+    /**
+     * What is stored for who a message went to: the domains it reached, deduped,
+     * and never the addresses themselves. The domain is the diagnostic part — a
+     * bounce is a bounce to gmail.com, not to a person — and the local part is
+     * the customer data the whole request position rests on not keeping.
+     *
+     * An application that has decided its recipients are safe to store opts the
+     * full addresses in, the same shape the payload capture takes.
+     *
+     * @param  array<int, string>  $addresses
+     */
+    private function mailRecipients(array $addresses): string
+    {
+        if (config('larabug.requests.capture_mail_recipients', false)) {
+            return implode(',', $addresses);
+        }
+
+        $domains = [];
+
+        foreach ($addresses as $address) {
+            $at = strrpos($address, '@');
+
+            if ($at !== false) {
+                $domains[$this->normalisedDomain(substr($address, $at + 1))] = true;
+            }
+        }
+
+        return implode(',', array_keys($domains));
+    }
+
+    private function normalisedDomain(string $domain): string
+    {
+        return strtolower(trim($domain, " \t\n\r\0\x0B>"));
+    }
+
+    /**
+     * How long the send took, when the sending event was seen for this same
+     * message. Zero when it was not: a mailer that only fires sent, or a message
+     * whose sending threw before the mark was read back.
+     */
+    private function mailDuration($message): float
+    {
+        $key = spl_object_id($message);
+
+        if (! isset($this->mailStartedAt[$key])) {
+            return 0.0;
+        }
+
+        $duration = round((microtime(true) - $this->mailStartedAt[$key]) * 1000, 3);
+
+        unset($this->mailStartedAt[$key]);
+
+        return $duration;
     }
 
     public function onNotificationSent($event): void

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -43,6 +43,9 @@ class RequestMonitor
     /** @var array<int, array<string, mixed>> */
     protected $outgoing = [];
 
+    /** @var array<int, array<string, mixed>> */
+    protected $mail = [];
+
     /** @var array<string, mixed>|null */
     protected $route = null;
 
@@ -58,10 +61,14 @@ class RequestMonitor
     /** @var int */
     protected $maxOutgoing;
 
+    /** @var int */
+    protected $maxMail;
+
     public function __construct()
     {
         $this->maxQueries = (int) config('larabug.requests.max_queries', 100);
         $this->maxOutgoing = (int) config('larabug.requests.max_outgoing', 50);
+        $this->maxMail = (int) config('larabug.requests.max_mail', 50);
 
         // LARAVEL_START is set in public/index.php before the framework boots,
         // so it is the only honest answer to "when did this request begin".
@@ -173,6 +180,28 @@ class RequestMonitor
     }
 
     /**
+     * Record one message sent.
+     *
+     * Carries the counter the same way recordOutgoing does, so the mail_sent
+     * tile still counts every message even on a request that sends more than the
+     * cap keeps. The recipients arrive as domains rather than addresses unless
+     * the application opted the full ones in: who a request emailed is personal
+     * data, and which service it emailed is the diagnostic part.
+     *
+     * @param  array<string, mixed>  $message
+     */
+    public function recordMail(array $message): void
+    {
+        $this->counters['mail_sent']++;
+
+        if (count($this->mail) >= $this->maxMail) {
+            return;
+        }
+
+        $this->mail[] = $message;
+    }
+
+    /**
      * The finished record.
      *
      * @return array<string, mixed>
@@ -235,6 +264,7 @@ class RequestMonitor
 
             'sql' => $this->queries,
             'outgoing' => $this->outgoing,
+            'mail' => $this->mail,
         ], $stages, $this->counters);
     }
 

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -437,6 +437,52 @@ class RequestMonitoringTest extends TestCase
         $this->assertCount(2, $record['mail']);
     }
 
+    /** @test */
+    public function it_records_a_queued_mailable_at_dispatch_marked_queued()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $mailable = new class extends \Illuminate\Mail\Mailable {};
+        $mailable->to('alice@example.com')->cc('team@other.test');
+
+        $event = new \stdClass();
+        $event->job = new \Illuminate\Mail\SendQueuedMailable($mailable);
+
+        $listeners->onJobQueued($event);
+
+        $record = $monitor->toArray(Request::create('/register', 'POST'), new Response('', 200), 1.0);
+
+        // The job is still a queued job, and now also a message.
+        $this->assertSame(1, $record['jobs_queued']);
+        $this->assertSame(1, $record['mail_sent']);
+        $this->assertCount(1, $record['mail']);
+
+        $message = $record['mail'][0];
+        $this->assertSame(get_class($mailable), $message['mailable']);
+        $this->assertSame(1, $message['to_count']);
+        $this->assertSame(1, $message['cc_count']);
+        $this->assertSame('example.com,other.test', $message['recipient_domains']);
+        $this->assertSame(1, $message['queued']);
+    }
+
+    /** @test */
+    public function a_queued_job_that_is_not_a_mailable_records_no_mail()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $event = new \stdClass();
+        $event->job = new \stdClass();
+
+        $listeners->onJobQueued($event);
+
+        $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
+
+        $this->assertSame(1, $record['jobs_queued']);
+        $this->assertSame([], $record['mail']);
+    }
+
     /**
      * A stand-in for a mail message. Symfony's Email and the older Swift message
      * share these getter names; this returns Address-shaped objects the way

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -320,6 +320,203 @@ class RequestMonitoringTest extends TestCase
         $this->assertCount(2, $record['outgoing']);
     }
 
+    /** @test */
+    public function it_records_a_message_with_its_recipient_domains_and_not_the_addresses()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $listeners->onMailSent($this->mailEvent($this->mailMessage(
+            'Welcome aboard',
+            ['alice@example.com', 'bob@example.com'],
+            ['team@other.test'],
+        )));
+
+        $record = $monitor->toArray(Request::create('/register', 'POST'), new Response('', 200), 1.0);
+
+        $this->assertSame(1, $record['mail_sent']);
+        $this->assertCount(1, $record['mail']);
+
+        $message = $record['mail'][0];
+        $this->assertSame('Welcome aboard', $message['subject']);
+        $this->assertSame(2, $message['to_count']);
+        $this->assertSame(1, $message['cc_count']);
+        $this->assertSame(0, $message['bcc_count']);
+        // Deduped domains, in recipient order, and never a local part.
+        $this->assertSame('example.com,other.test', $message['recipient_domains']);
+        $this->assertStringNotContainsString('alice', $message['recipient_domains']);
+    }
+
+    /** @test */
+    public function it_keeps_the_full_recipient_addresses_only_when_they_are_opted_in()
+    {
+        config(['larabug.requests.capture_mail_recipients' => true]);
+
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $listeners->onMailSent($this->mailEvent($this->mailMessage('Receipt', ['alice@example.com'])));
+
+        $message = $monitor->toArray(Request::create('/orders', 'POST'), new Response('', 200), 1.0)['mail'][0];
+
+        $this->assertSame('alice@example.com', $message['recipient_domains']);
+    }
+
+    /** @test */
+    public function it_resolves_the_mailable_class_from_the_call_stack()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $event = $this->mailEvent($this->mailMessage('Hi', ['a@b.test']));
+
+        // The resolver walks the stack for a Mailable frame; firing the event
+        // from inside one is what a real send does.
+        $mailable = new class extends \Illuminate\Mail\Mailable {
+            public function fire(RequestListeners $listeners, object $event): void
+            {
+                $listeners->onMailSent($event);
+            }
+        };
+
+        $mailable->fire($listeners, $event);
+
+        $message = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0)['mail'][0];
+
+        $this->assertSame(get_class($mailable), $message['mailable']);
+    }
+
+    /** @test */
+    public function mail_sent_without_a_mailable_carries_an_empty_class()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $listeners->onMailSent($this->mailEvent($this->mailMessage('Raw', ['a@b.test'])));
+
+        $this->assertSame('', $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0)['mail'][0]['mailable']);
+    }
+
+    /** @test */
+    public function it_times_a_send_from_its_sending_event()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $event = $this->mailEvent($this->mailMessage('Timed', ['a@b.test']));
+
+        $listeners->onMailSending($event);
+        usleep(2000);
+        $listeners->onMailSent($event);
+
+        $message = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0)['mail'][0];
+
+        // Paired with its sending event, so a real duration rather than the zero
+        // a sent-only mailer leaves.
+        $this->assertGreaterThan(0, $message['duration_ms']);
+    }
+
+    /** @test */
+    public function the_mail_counter_keeps_counting_past_the_cap()
+    {
+        config(['larabug.requests.max_mail' => 2]);
+
+        $monitor = new RequestMonitor();
+
+        for ($i = 0; $i < 5; $i++) {
+            $monitor->recordMail([
+                'mailable' => '', 'subject' => "m{$i}", 'to_count' => 1, 'cc_count' => 0,
+                'bcc_count' => 0, 'recipient_domains' => 'x.test', 'queued' => 0, 'duration_ms' => 0.0,
+            ]);
+        }
+
+        $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
+
+        // All five counted, only two kept.
+        $this->assertSame(5, $record['mail_sent']);
+        $this->assertCount(2, $record['mail']);
+    }
+
+    /**
+     * A stand-in for a mail message. Symfony's Email and the older Swift message
+     * share these getter names; this returns Address-shaped objects the way
+     * Symfony does, which is what current Laravel hands the event.
+     *
+     * @param  array<int, string>  $to
+     * @param  array<int, string>  $cc
+     * @param  array<int, string>  $bcc
+     */
+    private function mailMessage(string $subject, array $to, array $cc = [], array $bcc = []): object
+    {
+        $address = fn (string $email): object => new class($email) {
+            /** @var string */
+            private $email;
+
+            public function __construct(string $email)
+            {
+                $this->email = $email;
+            }
+
+            public function getAddress(): string
+            {
+                return $this->email;
+            }
+        };
+
+        return new class($subject, array_map($address, $to), array_map($address, $cc), array_map($address, $bcc)) {
+            /** @var string */
+            public $subject;
+
+            /** @var array<int, object> */
+            public $to;
+
+            /** @var array<int, object> */
+            public $cc;
+
+            /** @var array<int, object> */
+            public $bcc;
+
+            public function __construct(string $subject, array $to, array $cc, array $bcc)
+            {
+                $this->subject = $subject;
+                $this->to = $to;
+                $this->cc = $cc;
+                $this->bcc = $bcc;
+            }
+
+            public function getSubject(): string
+            {
+                return $this->subject;
+            }
+
+            /** @return array<int, object> */
+            public function getTo(): array
+            {
+                return $this->to;
+            }
+
+            /** @return array<int, object> */
+            public function getCc(): array
+            {
+                return $this->cc;
+            }
+
+            /** @return array<int, object> */
+            public function getBcc(): array
+            {
+                return $this->bcc;
+            }
+        };
+    }
+
+    private function mailEvent(object $message): object
+    {
+        $event = new \stdClass();
+        $event->message = $message;
+
+        return $event;
+    }
+
     /**
      * A stand-in for an Http client event: the handler reads only ->request and
      * ->response, so a plain object with those is enough and sidesteps the


### PR DESCRIPTION
Records the mailable class, subject, recipient counts, the domains it reached and the send duration for each message a sampled request sends, buffered on RequestMonitor beside the queries and outgoing calls and capped by max_mail (default 50). A queued mailable is caught at dispatch off the SendQueuedMailable the JobQueued event carries, since its own send is a worker away, and marked queued. Recipients are kept as domains rather than addresses unless capture_mail_recipients opts the full ones in. Pairs with larabug-app.