### PR TITLE
Capture each cache operation, not just the count

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -268,6 +268,15 @@ return [
         'max_notifications' => env('LB_REQUEST_MAX_NOTIFICATIONS', 50),
 
         /*
+        | How many cache operations are kept per request
+        | The hit and miss counters keep counting past this on their own; a
+        | request that touches the cache a thousand times is common, and the
+        | first hundred operations are enough to read its shape
+        | Default: 100
+        */
+        'max_cache_events' => env('LB_REQUEST_MAX_CACHE_EVENTS', 100),
+
+        /*
         | How many records are held before they are sent
         | A web process serves one request, so this mostly matters for Octane
         | and for the console
@@ -296,6 +305,15 @@ return [
         | Default: false
         */
         'capture_mail_recipients' => env('LB_REQUEST_CAPTURE_MAIL_RECIPIENTS', false),
+
+        /*
+        | Whether full cache keys are recorded
+        | Off by default: a key up to its first colon is kept, which is the store
+        | and the kind of thing cached, and the id after it is dropped the way a
+        | query's bindings are. Turn this on only where the keys are yours to keep
+        | Default: false
+        */
+        'capture_cache_keys' => env('LB_REQUEST_CAPTURE_CACHE_KEYS', false),
 
         /*
         | Whether request headers are recorded

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -44,6 +44,8 @@ class RequestListeners
         $events->listen('Illuminate\Database\Events\QueryExecuted', [$this, 'onQueryExecuted']);
         $events->listen('Illuminate\Cache\Events\CacheHit', [$this, 'onCacheHit']);
         $events->listen('Illuminate\Cache\Events\CacheMissed', [$this, 'onCacheMissed']);
+        $events->listen('Illuminate\Cache\Events\KeyWritten', [$this, 'onCacheWritten']);
+        $events->listen('Illuminate\Cache\Events\KeyForgotten', [$this, 'onCacheForgotten']);
         $events->listen('Illuminate\Queue\Events\JobQueued', [$this, 'onJobQueued']);
 
         // Paired: the sending event only starts a timer, the sent event is what
@@ -105,16 +107,71 @@ class RequestListeners
 
     public function onCacheHit($event): void
     {
-        $this->guard(function () {
+        $this->guard(function () use ($event) {
             $this->monitor->increment('cache_hits');
+            $this->recordCacheEvent('hit', $event);
         });
     }
 
     public function onCacheMissed($event): void
     {
-        $this->guard(function () {
+        $this->guard(function () use ($event) {
             $this->monitor->increment('cache_misses');
+            $this->recordCacheEvent('miss', $event);
         });
+    }
+
+    public function onCacheWritten($event): void
+    {
+        $this->guard(function () use ($event) {
+            $this->recordCacheEvent('write', $event);
+        });
+    }
+
+    public function onCacheForgotten($event): void
+    {
+        $this->guard(function () use ($event) {
+            $this->recordCacheEvent('forget', $event);
+        });
+    }
+
+    /**
+     * Buffer one cache operation. The key is narrowed to a prefix unless the
+     * application opted the full keys in; the ttl is only meaningful on a write.
+     *
+     * @param  mixed  $event
+     */
+    private function recordCacheEvent(string $op, $event): void
+    {
+        $this->monitor->recordCacheEvent([
+            'op' => $op,
+            'key_prefix' => $this->cacheKey((string) ($event->key ?? '')),
+            'store' => (string) ($event->storeName ?? ''),
+            'ttl' => $op === 'write' ? (int) ($event->seconds ?? 0) : 0,
+        ]);
+    }
+
+    /**
+     * A cache key narrowed to what is safe to keep. Laravel's keys are routinely
+     * "prefix:id", and the prefix is the diagnostic part while the id is customer
+     * data; the part up to the first colon keeps the former and drops the latter.
+     * A key with no colon is bounded to a fixed length. An application that has
+     * decided its keys are safe keeps them whole, the same shape the payload
+     * capture takes.
+     */
+    private function cacheKey(string $key): string
+    {
+        if (config('larabug.requests.capture_cache_keys', false)) {
+            return mb_substr($key, 0, 255);
+        }
+
+        $colon = strpos($key, ':');
+
+        if ($colon > 0) {
+            return mb_substr($key, 0, $colon);
+        }
+
+        return mb_substr($key, 0, 64);
     }
 
     public function onJobQueued($event): void

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -49,6 +49,9 @@ class RequestMonitor
     /** @var array<int, array<string, mixed>> */
     protected $notifications = [];
 
+    /** @var array<int, array<string, mixed>> */
+    protected $cache = [];
+
     /** @var array<string, mixed>|null */
     protected $route = null;
 
@@ -70,12 +73,16 @@ class RequestMonitor
     /** @var int */
     protected $maxNotifications;
 
+    /** @var int */
+    protected $maxCacheEvents;
+
     public function __construct()
     {
         $this->maxQueries = (int) config('larabug.requests.max_queries', 100);
         $this->maxOutgoing = (int) config('larabug.requests.max_outgoing', 50);
         $this->maxMail = (int) config('larabug.requests.max_mail', 50);
         $this->maxNotifications = (int) config('larabug.requests.max_notifications', 50);
+        $this->maxCacheEvents = (int) config('larabug.requests.max_cache_events', 100);
 
         // LARAVEL_START is set in public/index.php before the framework boots,
         // so it is the only honest answer to "when did this request begin".
@@ -231,6 +238,27 @@ class RequestMonitor
     }
 
     /**
+     * Record one cache operation.
+     *
+     * The hit and miss counters are kept by their own listeners, so this only
+     * buffers the detail and is capped on its own: a request that reads the cache
+     * a thousand times is common, and the first hundred operations are enough to
+     * see its shape. The key arrives already narrowed to a prefix unless the
+     * application opted the full keys in, the same stance the query bindings take:
+     * a cache key routinely carries an id, which is customer data.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    public function recordCacheEvent(array $event): void
+    {
+        if (count($this->cache) >= $this->maxCacheEvents) {
+            return;
+        }
+
+        $this->cache[] = $event;
+    }
+
+    /**
      * The finished record.
      *
      * @return array<string, mixed>
@@ -295,6 +323,7 @@ class RequestMonitor
             'outgoing' => $this->outgoing,
             'mail' => $this->mail,
             'notifications' => $this->notifications,
+            'cache' => $this->cache,
         ], $stages, $this->counters);
     }
 

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -520,6 +520,80 @@ class RequestMonitoringTest extends TestCase
     }
 
     /** @test */
+    public function it_records_cache_operations_with_the_key_narrowed_to_a_prefix()
+    {
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $listeners->onCacheHit($this->cacheEvent('user:42:profile', 'redis'));
+        $listeners->onCacheMissed($this->cacheEvent('config:mail', 'redis'));
+        $listeners->onCacheWritten($this->cacheEvent('user:42:profile', 'redis', 3600));
+        $listeners->onCacheForgotten($this->cacheEvent('user:42:profile', 'redis'));
+
+        $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
+
+        // The hit and miss counters still track their totals.
+        $this->assertSame(1, $record['cache_hits']);
+        $this->assertSame(1, $record['cache_misses']);
+
+        $this->assertCount(4, $record['cache']);
+        $this->assertSame(['hit', 'miss', 'write', 'forget'], array_column($record['cache'], 'op'));
+
+        $hit = $record['cache'][0];
+        // The prefix up to the first colon; the id after it is dropped.
+        $this->assertSame('user', $hit['key_prefix']);
+        $this->assertSame('redis', $hit['store']);
+
+        // A ttl only means something on a write.
+        $this->assertSame(3600, $record['cache'][2]['ttl']);
+        $this->assertSame(0, $record['cache'][0]['ttl']);
+    }
+
+    /** @test */
+    public function it_keeps_the_full_cache_key_only_when_opted_in()
+    {
+        config(['larabug.requests.capture_cache_keys' => true]);
+
+        $monitor = new RequestMonitor();
+        $listeners = new RequestListeners($monitor, new Sampler());
+
+        $listeners->onCacheHit($this->cacheEvent('user:42:profile', 'redis'));
+
+        $event = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0)['cache'][0];
+
+        $this->assertSame('user:42:profile', $event['key_prefix']);
+    }
+
+    /** @test */
+    public function the_cache_buffer_is_capped()
+    {
+        config(['larabug.requests.max_cache_events' => 2]);
+
+        $monitor = new RequestMonitor();
+
+        for ($i = 0; $i < 5; $i++) {
+            $monitor->recordCacheEvent(['op' => 'hit', 'key_prefix' => 'k', 'store' => 'redis', 'ttl' => 0]);
+        }
+
+        $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
+
+        $this->assertCount(2, $record['cache']);
+    }
+
+    private function cacheEvent(string $key, string $store, ?int $seconds = null): object
+    {
+        $event = new \stdClass();
+        $event->key = $key;
+        $event->storeName = $store;
+
+        if ($seconds !== null) {
+            $event->seconds = $seconds;
+        }
+
+        return $event;
+    }
+
+    /** @test */
     public function it_records_a_queued_mailable_at_dispatch_marked_queued()
     {
         $monitor = new RequestMonitor();


### PR DESCRIPTION
Record the op (hit, miss, write, forget), the store, a ttl on writes, and the key narrowed to its prefix for each cache operation a sampled request makes, buffered on RequestMonitor and capped by max_cache_events. Adds the KeyWritten and KeyForgotten listeners. Keys are kept up to the first colon unless capture_cache_keys opts the full ones in.