### PR TITLE
Track artisan command executions

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -361,6 +361,66 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Command Monitoring
+    |--------------------------------------------------------------------------
+    |
+    | Records the artisan commands this application runs: how long each took, the
+    | code it exited with, and the arguments it was given. A separate execution
+    | context from a request, so it has its own switch.
+    |
+    | Off by default, and kept whole rather than sampled: commands run at nothing
+    | like request volume, and the one that failed at 3am is the one worth having.
+    |
+    */
+    'commands' => [
+        /*
+        | Enable or disable command monitoring
+        | Set to true via LB_TRACK_COMMANDS=true to start recording
+        | Default: false (opt-in)
+        */
+        'track_commands' => env('LB_TRACK_COMMANDS', false),
+
+        /*
+        | Commands never recorded, matched with fnmatch against the command name
+        | The workers and schedulers that run forever or every minute would drown
+        | the real commands, and this package's own commands would report on
+        | themselves
+        */
+        'ignore' => [
+            'schedule:run',
+            'schedule:finish',
+            'schedule:work',
+            'queue:work',
+            'queue:listen',
+            'horizon',
+            'horizon:*',
+            'larabug:*',
+            'list',
+            'tinker',
+        ],
+
+        /*
+        | Arguments and options replaced with a marker before sending, matched
+        | against the name at any depth, case-insensitively, as a substring
+        */
+        'redact' => [
+            'password',
+            'secret',
+            'token',
+            'key',
+        ],
+
+        /*
+        | How many records are held before they are sent, and the retries on a
+        | 5xx. A console process runs one command and exits, so the shutdown flush
+        | usually sends a batch of one
+        */
+        'batch_size' => env('LB_COMMAND_BATCH_SIZE', 20),
+        'max_retries' => env('LB_COMMAND_MAX_RETRIES', 2),
+    ],
+
     'heartbeat' => [
         /*
         | Enable or disable the heartbeat

--- a/src/Console/CommandBuffer.php
+++ b/src/Console/CommandBuffer.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace LaraBug\Console;
+
+use Countable;
+use LaraBug\Http\Client;
+use Throwable;
+
+/**
+ * Batches finished command records.
+ *
+ * The console counterpart to RequestBuffer. A console process runs one command
+ * and then exits, so the flush happens on shutdown as well as on size: without
+ * it the record of the command that just finished would be lost at the moment it
+ * completed. A long-running worker that this package does not ignore would flush
+ * on size instead, but those are on the ignore list precisely because they never
+ * finish.
+ */
+class CommandBuffer implements Countable
+{
+    /** @var array<int, array<string, mixed>> */
+    protected $buffer = [];
+
+    /** @var Client */
+    protected $client;
+
+    /** @var array<string, mixed> */
+    protected $config;
+
+    /** @var int */
+    protected $batchSize;
+
+    /** @var int */
+    protected $maxRetries;
+
+    /** @var bool */
+    protected $shutdownRegistered = false;
+
+    public function __construct(Client $client, array $config)
+    {
+        $this->client = $client;
+        $this->config = $config;
+        $this->batchSize = (int) ($config['commands']['batch_size'] ?? 20);
+        $this->maxRetries = (int) ($config['commands']['max_retries'] ?? 2);
+
+        $this->registerShutdownHandler();
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     */
+    public function add(array $record): void
+    {
+        $this->buffer[] = $record;
+
+        if (count($this->buffer) >= $this->batchSize) {
+            $this->flush();
+        }
+    }
+
+    public function flush(): void
+    {
+        if ($this->buffer === []) {
+            return;
+        }
+
+        $records = $this->buffer;
+        $this->buffer = [];
+
+        $this->send($records);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $records
+     */
+    protected function send(array $records, int $attempt = 1): void
+    {
+        try {
+            $this->client->reportCommands($records);
+        } catch (Throwable $e) {
+            if ($attempt <= $this->maxRetries) {
+                usleep(100000 * $attempt);
+
+                $this->send($records, $attempt + 1);
+
+                return;
+            }
+
+            // Nothing else. A monitoring package that throws on the way out is a
+            // monitoring package that takes the application down with it.
+        }
+    }
+
+    protected function registerShutdownHandler(): void
+    {
+        if ($this->shutdownRegistered) {
+            return;
+        }
+
+        $this->shutdownRegistered = true;
+
+        register_shutdown_function(function () {
+            $this->flush();
+        });
+    }
+
+    public function count(): int
+    {
+        return count($this->buffer);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function pending(): array
+    {
+        return $this->buffer;
+    }
+}

--- a/src/Console/CommandListeners.php
+++ b/src/Console/CommandListeners.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace LaraBug\Console;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use LaraBug\Requests\TraceContext;
+use Throwable;
+
+/**
+ * The events that fill in a command record.
+ *
+ * Subscribed only when command tracking is on. A command is its own execution
+ * context, neither a request nor a job, so it carries its own trace and its own
+ * buffer. The handlers are stacked rather than keyed on a single current
+ * command, because a command can call another (Artisan::call), and a finish has
+ * to match the start it belongs to.
+ */
+class CommandListeners
+{
+    /** @var CommandBuffer */
+    protected $buffer;
+
+    /** @var array<int, array<string, mixed>|null> The commands in flight. */
+    protected $stack = [];
+
+    public function __construct(CommandBuffer $buffer)
+    {
+        $this->buffer = $buffer;
+    }
+
+    /**
+     * Registered one at a time rather than by returning a map, the same as the
+     * request listeners: this package supports Laravel 6, whose dispatcher does
+     * not read a subscribe map.
+     */
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen('Illuminate\Console\Events\CommandStarting', [$this, 'onCommandStarting']);
+        $events->listen('Illuminate\Console\Events\CommandFinished', [$this, 'onCommandFinished']);
+    }
+
+    public function onCommandStarting($event): void
+    {
+        $this->guard(function () use ($event) {
+            $command = (string) ($event->command ?? '');
+
+            if ($command === '' || $this->ignored($command)) {
+                // A null frame keeps the finish handler's stack balanced without
+                // recording the ignored command.
+                $this->stack[] = null;
+
+                return;
+            }
+
+            // Each command is its own unit of work, so each gets its own trace,
+            // the same as a queued job. A console process that runs several in a
+            // row would otherwise stamp them all with the first one's id.
+            TraceContext::reset();
+
+            $this->stack[] = [
+                'command' => $command,
+                'trace_id' => TraceContext::id(),
+                'started_at' => gmdate('Y-m-d H:i:s'),
+                'start' => microtime(true),
+            ];
+        });
+    }
+
+    public function onCommandFinished($event): void
+    {
+        $this->guard(function () use ($event) {
+            if ($this->stack === []) {
+                return;
+            }
+
+            $frame = array_pop($this->stack);
+
+            if ($frame === null) {
+                return;
+            }
+
+            $this->buffer->add([
+                'command' => $frame['command'],
+                'exit_code' => (int) ($event->exitCode ?? 0),
+                'duration_ms' => round((microtime(true) - $frame['start']) * 1000, 3),
+                'memory_peak_kb' => (int) round(memory_get_peak_usage(true) / 1024),
+
+                // The same id any log lines and exceptions from this command
+                // carry, which is the whole reason to keep it.
+                'trace_id' => $frame['trace_id'],
+
+                'arguments' => $this->arguments($event->input ?? null),
+
+                'environment' => (string) config('app.env'),
+                'release' => (string) config('larabug.project_version', ''),
+                'host' => (string) gethostname(),
+                'started_at' => $frame['started_at'],
+            ]);
+        });
+    }
+
+    protected function ignored(string $command): bool
+    {
+        foreach ((array) config('larabug.commands.ignore', []) as $pattern) {
+            if (fnmatch($pattern, $command)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The arguments and options a command was given, as JSON, with the sensitive
+     * ones replaced by a marker. Read off the input and guarded: the input is a
+     * Symfony contract whose getters throw when the definition is not bound, and
+     * a command that could not be detailed is still worth counting.
+     *
+     * @param  mixed  $input
+     */
+    protected function arguments($input): string
+    {
+        if (! is_object($input)) {
+            return '';
+        }
+
+        $redact = array_map('strtolower', (array) config('larabug.commands.redact', []));
+
+        $bag = [];
+
+        try {
+            if (method_exists($input, 'getArguments')) {
+                foreach ($input->getArguments() as $name => $value) {
+                    // The command name is the record's own column, not an argument.
+                    if ($name === 'command') {
+                        continue;
+                    }
+
+                    $bag['arguments'][$name] = $this->redactValue((string) $name, $value, $redact);
+                }
+            }
+
+            if (method_exists($input, 'getOptions')) {
+                foreach ($input->getOptions() as $name => $value) {
+                    $bag['options'][$name] = $this->redactValue((string) $name, $value, $redact);
+                }
+            }
+        } catch (Throwable $e) {
+            return '';
+        }
+
+        return (string) json_encode($bag);
+    }
+
+    /**
+     * @param  mixed  $value
+     * @param  array<int, string>  $redact  lowercased needles
+     * @return mixed
+     */
+    protected function redactValue(string $name, $value, array $redact)
+    {
+        $lower = strtolower($name);
+
+        foreach ($redact as $needle) {
+            if ($needle !== '' && strpos($lower, $needle) !== false) {
+                return '[redacted]';
+            }
+        }
+
+        return $value;
+    }
+
+    protected function guard(callable $callback): void
+    {
+        try {
+            $callback();
+        } catch (Throwable $e) {
+            // Never let instrumentation surface in the application's own output.
+        }
+    }
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -102,6 +102,35 @@ class Client
     }
 
     /**
+     * @param  array<int, array<string, mixed>>  $records
+     */
+    public function reportCommands(array $records)
+    {
+        try {
+            return $this->getGuzzleHttpClient()->request('POST', config('larabug.server'), [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$this->login,
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'LaraBug-Package',
+                ],
+                'json' => [
+                    'type' => 'commands_batch',
+                    'project' => $this->project,
+                    'commands' => $records,
+                    'count' => count($records),
+                ],
+                'verify' => config('larabug.verify_ssl'),
+                'timeout' => 5,
+            ]);
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            return $e->getResponse();
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * Report that this app's workers are alive.
      *
      * Its own endpoint rather than a kind of report: this arrives on a schedule

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,6 +98,12 @@ class ServiceProvider extends BaseServiceProvider
             $this->app['events']->subscribe(\LaraBug\Queue\JobEventSubscriber::class);
         }
 
+        // Command monitoring. The inverse of request monitoring: a command runs
+        // in the console, so this is not gated behind runningInConsole.
+        if (config('larabug.commands.track_commands', false)) {
+            $this->app['events']->subscribe(\LaraBug\Console\CommandListeners::class);
+        }
+
         // The heartbeat only has a job to do where the scheduler runs, which is
         // also the only place it can be registered from.
         if (config('larabug.heartbeat.enabled', true)) {
@@ -319,6 +325,13 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->singleton(\LaraBug\Requests\RequestBuffer::class, function ($app) {
             return new \LaraBug\Requests\RequestBuffer(
+                $app->make(\LaraBug\Http\Client::class),
+                config('larabug')
+            );
+        });
+
+        $this->app->singleton(\LaraBug\Console\CommandBuffer::class, function ($app) {
+            return new \LaraBug\Console\CommandBuffer(
                 $app->make(\LaraBug\Http\Client::class),
                 config('larabug')
             );

--- a/tests/CommandMonitoringTest.php
+++ b/tests/CommandMonitoringTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use LaraBug\Console\CommandBuffer;
+use LaraBug\Console\CommandListeners;
+
+class CommandMonitoringTest extends TestCase
+{
+    /** @test */
+    public function it_records_a_finished_command_with_its_exit_code_and_arguments()
+    {
+        config(['larabug.commands.redact' => ['password']]);
+
+        $buffer = $this->recordingBuffer();
+        $listeners = new CommandListeners($buffer);
+
+        $input = $this->fakeInput(['command' => 'migrate', 'connection' => 'mysql'], ['force' => true, 'password' => 'hunter2']);
+
+        $listeners->onCommandStarting($this->startingEvent('migrate', $input));
+        $listeners->onCommandFinished($this->finishedEvent('migrate', 0, $input));
+
+        $this->assertCount(1, $buffer->records);
+
+        $record = $buffer->records[0];
+        $this->assertSame('migrate', $record['command']);
+        $this->assertSame(0, $record['exit_code']);
+        // A command is its own execution, so it has a trace of its own.
+        $this->assertNotSame('', $record['trace_id']);
+
+        $arguments = json_decode($record['arguments'], true);
+        // The command name is the record's own column, not an argument.
+        $this->assertArrayNotHasKey('command', $arguments['arguments']);
+        $this->assertSame('mysql', $arguments['arguments']['connection']);
+        // The password option is replaced with a marker.
+        $this->assertSame('[redacted]', $arguments['options']['password']);
+        $this->assertTrue($arguments['options']['force']);
+    }
+
+    /** @test */
+    public function it_does_not_record_an_ignored_command()
+    {
+        config(['larabug.commands.ignore' => ['queue:work', 'horizon:*']]);
+
+        $buffer = $this->recordingBuffer();
+        $listeners = new CommandListeners($buffer);
+        $input = $this->fakeInput([], []);
+
+        $listeners->onCommandStarting($this->startingEvent('horizon:work', $input));
+        $listeners->onCommandFinished($this->finishedEvent('horizon:work', 0, $input));
+
+        $this->assertCount(0, $buffer->records);
+    }
+
+    /** @test */
+    public function a_failing_command_carries_its_non_zero_exit_code()
+    {
+        $buffer = $this->recordingBuffer();
+        $listeners = new CommandListeners($buffer);
+        $input = $this->fakeInput([], []);
+
+        $listeners->onCommandStarting($this->startingEvent('backup:run', $input));
+        $listeners->onCommandFinished($this->finishedEvent('backup:run', 1, $input));
+
+        $this->assertSame(1, $buffer->records[0]['exit_code']);
+    }
+
+    /** @test */
+    public function nested_commands_each_get_their_own_record()
+    {
+        $buffer = $this->recordingBuffer();
+        $listeners = new CommandListeners($buffer);
+        $input = $this->fakeInput([], []);
+
+        // An outer command calls an inner one: starting, starting, finished,
+        // finished. Each finish must match the start it belongs to.
+        $listeners->onCommandStarting($this->startingEvent('app:outer', $input));
+        $listeners->onCommandStarting($this->startingEvent('app:inner', $input));
+        $listeners->onCommandFinished($this->finishedEvent('app:inner', 0, $input));
+        $listeners->onCommandFinished($this->finishedEvent('app:outer', 0, $input));
+
+        $this->assertSame(['app:inner', 'app:outer'], array_column($buffer->records, 'command'));
+    }
+
+    private function recordingBuffer(): CommandBuffer
+    {
+        // A buffer that records rather than sends. It skips the parent
+        // constructor, so no shutdown flush is registered and no client is
+        // needed for a test that only cares what was buffered.
+        return new class extends CommandBuffer {
+            /** @var array<int, array<string, mixed>> */
+            public $records = [];
+
+            public function __construct()
+            {
+            }
+
+            public function add(array $record): void
+            {
+                $this->records[] = $record;
+            }
+        };
+    }
+
+    private function startingEvent(string $command, object $input): object
+    {
+        $event = new \stdClass();
+        $event->command = $command;
+        $event->input = $input;
+
+        return $event;
+    }
+
+    private function finishedEvent(string $command, int $exitCode, object $input): object
+    {
+        $event = new \stdClass();
+        $event->command = $command;
+        $event->exitCode = $exitCode;
+        $event->input = $input;
+
+        return $event;
+    }
+
+    /**
+     * A stand-in for the console input: the handler reads only getArguments and
+     * getOptions, so a plain object with those is enough.
+     *
+     * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>  $options
+     */
+    private function fakeInput(array $arguments, array $options): object
+    {
+        return new class($arguments, $options) {
+            /** @var array<string, mixed> */
+            private $arguments;
+
+            /** @var array<string, mixed> */
+            private $options;
+
+            public function __construct(array $arguments, array $options)
+            {
+                $this->arguments = $arguments;
+                $this->options = $options;
+            }
+
+            /** @return array<string, mixed> */
+            public function getArguments(): array
+            {
+                return $this->arguments;
+            }
+
+            /** @return array<string, mixed> */
+            public function getOptions(): array
+            {
+                return $this->options;
+            }
+        };
+    }
+}


### PR DESCRIPTION
A command is its own execution context. A CommandListeners subscriber hooks CommandStarting and CommandFinished, resets the trace at the start like a queued job, and on finish records the command, exit code, duration, peak memory and its arguments (sensitive ones marked) into a CommandBuffer that ships on shutdown. Off by default via track_commands, kept whole, with an ignore list for the workers and schedulers that never finish.