### PR TITLE
Track scheduled task runs

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -421,6 +421,32 @@ return [
         'max_retries' => env('LB_COMMAND_MAX_RETRIES', 2),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Scheduled Task Monitoring
+    |--------------------------------------------------------------------------
+    |
+    | Records the scheduled tasks this application runs: whether each ran, failed
+    | or was skipped, how long it took, and the cron it runs on. Its own context,
+    | told apart from a standalone command run: a scheduled command emits command
+    | events too, and the command listener bows out while a task is in flight so
+    | the run is counted once, against the schedule.
+    |
+    | Off by default. Kept whole, the same as commands.
+    |
+    */
+    'schedule' => [
+        /*
+        | Enable or disable scheduled task monitoring
+        | Set to true via LB_TRACK_SCHEDULED_TASKS=true to start recording
+        | Default: false (opt-in)
+        */
+        'track_scheduled_tasks' => env('LB_TRACK_SCHEDULED_TASKS', false),
+
+        'batch_size' => env('LB_SCHEDULED_TASK_BATCH_SIZE', 20),
+        'max_retries' => env('LB_SCHEDULED_TASK_MAX_RETRIES', 2),
+    ],
+
     'heartbeat' => [
         /*
         | Enable or disable the heartbeat

--- a/src/Console/CommandListeners.php
+++ b/src/Console/CommandListeners.php
@@ -44,9 +44,11 @@ class CommandListeners
         $this->guard(function () use ($event) {
             $command = (string) ($event->command ?? '');
 
-            if ($command === '' || $this->ignored($command)) {
-                // A null frame keeps the finish handler's stack balanced without
-                // recording the ignored command.
+            // A command run by the scheduler in the same process belongs to the
+            // schedule, not to commands: the scheduled task listener counts it,
+            // and counting it here too would double it. A null frame keeps the
+            // finish handler's stack balanced without recording it.
+            if ($command === '' || $this->ignored($command) || ScheduledTaskListeners::$inFlight > 0) {
                 $this->stack[] = null;
 
                 return;

--- a/src/Console/ScheduledTaskBuffer.php
+++ b/src/Console/ScheduledTaskBuffer.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace LaraBug\Console;
+
+use Countable;
+use LaraBug\Http\Client;
+use Throwable;
+
+/**
+ * Batches finished scheduled task records.
+ *
+ * Its own buffer rather than the command one, because the two are told apart on
+ * the way out by which sender they use: a task ships as a scheduled_tasks_batch,
+ * a command as a commands_batch. The scheduler runs inside a single schedule:run
+ * process, so this flushes on shutdown like the command buffer.
+ */
+class ScheduledTaskBuffer implements Countable
+{
+    /** @var array<int, array<string, mixed>> */
+    protected $buffer = [];
+
+    /** @var Client */
+    protected $client;
+
+    /** @var array<string, mixed> */
+    protected $config;
+
+    /** @var int */
+    protected $batchSize;
+
+    /** @var int */
+    protected $maxRetries;
+
+    /** @var bool */
+    protected $shutdownRegistered = false;
+
+    public function __construct(Client $client, array $config)
+    {
+        $this->client = $client;
+        $this->config = $config;
+        $this->batchSize = (int) ($config['schedule']['batch_size'] ?? 20);
+        $this->maxRetries = (int) ($config['schedule']['max_retries'] ?? 2);
+
+        $this->registerShutdownHandler();
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     */
+    public function add(array $record): void
+    {
+        $this->buffer[] = $record;
+
+        if (count($this->buffer) >= $this->batchSize) {
+            $this->flush();
+        }
+    }
+
+    public function flush(): void
+    {
+        if ($this->buffer === []) {
+            return;
+        }
+
+        $records = $this->buffer;
+        $this->buffer = [];
+
+        $this->send($records);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $records
+     */
+    protected function send(array $records, int $attempt = 1): void
+    {
+        try {
+            $this->client->reportScheduledTasks($records);
+        } catch (Throwable $e) {
+            if ($attempt <= $this->maxRetries) {
+                usleep(100000 * $attempt);
+
+                $this->send($records, $attempt + 1);
+
+                return;
+            }
+
+            // Nothing else. A monitoring package that throws on the way out is a
+            // monitoring package that takes the application down with it.
+        }
+    }
+
+    protected function registerShutdownHandler(): void
+    {
+        if ($this->shutdownRegistered) {
+            return;
+        }
+
+        $this->shutdownRegistered = true;
+
+        register_shutdown_function(function () {
+            $this->flush();
+        });
+    }
+
+    public function count(): int
+    {
+        return count($this->buffer);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function pending(): array
+    {
+        return $this->buffer;
+    }
+}

--- a/src/Console/ScheduledTaskListeners.php
+++ b/src/Console/ScheduledTaskListeners.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace LaraBug\Console;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use LaraBug\Requests\TraceContext;
+use Throwable;
+
+/**
+ * The events that fill in a scheduled task record.
+ *
+ * Subscribed only when scheduled task tracking is on. A scheduled task is its
+ * own execution context, and a scheduled command run is attributed here rather
+ * than to commands: the in-flight counter this keeps is what the command
+ * listener reads to bow out while a task is running, so the run is counted once.
+ */
+class ScheduledTaskListeners
+{
+    /**
+     * How many scheduled tasks are running right now. The command listener reads
+     * this to attribute a scheduled command run to the schedule rather than to
+     * commands. A counter, not a flag, because a task can, in principle, run
+     * inside another.
+     *
+     * @var int
+     */
+    public static $inFlight = 0;
+
+    /** @var ScheduledTaskBuffer */
+    protected $buffer;
+
+    /** @var array<int, float> Start marks, keyed by the task object. */
+    protected $startedAt = [];
+
+    public function __construct(ScheduledTaskBuffer $buffer)
+    {
+        $this->buffer = $buffer;
+    }
+
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen('Illuminate\Console\Events\ScheduledTaskStarting', [$this, 'onScheduledTaskStarting']);
+        $events->listen('Illuminate\Console\Events\ScheduledTaskFinished', [$this, 'onScheduledTaskFinished']);
+        $events->listen('Illuminate\Console\Events\ScheduledTaskFailed', [$this, 'onScheduledTaskFailed']);
+        $events->listen('Illuminate\Console\Events\ScheduledTaskSkipped', [$this, 'onScheduledTaskSkipped']);
+    }
+
+    public function onScheduledTaskStarting($event): void
+    {
+        $this->guard(function () use ($event) {
+            self::$inFlight++;
+
+            // Each task is its own unit of work, so each gets its own trace, the
+            // same as a queued job or a command.
+            TraceContext::reset();
+
+            $task = $event->task ?? null;
+
+            if (is_object($task)) {
+                $this->startedAt[spl_object_id($task)] = microtime(true);
+            }
+        });
+    }
+
+    public function onScheduledTaskFinished($event): void
+    {
+        $this->record($event, 'ran');
+    }
+
+    public function onScheduledTaskFailed($event): void
+    {
+        $this->record($event, 'failed');
+    }
+
+    public function onScheduledTaskSkipped($event): void
+    {
+        // A skipped task never started, so the in-flight counter was not raised
+        // for it and nothing needs releasing here.
+        $this->guard(function () use ($event) {
+            $this->buffer->add($this->toRecord($event->task ?? null, 'skipped', 0.0));
+        });
+    }
+
+    /**
+     * @param  mixed  $event
+     */
+    protected function record($event, string $status): void
+    {
+        $this->guard(function () use ($event, $status) {
+            if (self::$inFlight > 0) {
+                self::$inFlight--;
+            }
+
+            $task = $event->task ?? null;
+            $duration = $this->duration($task, $event);
+
+            $this->buffer->add($this->toRecord($task, $status, $duration));
+        });
+    }
+
+    /**
+     * @param  mixed  $task
+     * @return array<string, mixed>
+     */
+    protected function toRecord($task, string $status, float $duration): array
+    {
+        return [
+            'task' => $this->taskName($task),
+            'expression' => is_object($task) ? (string) ($task->expression ?? '') : '',
+            'status' => $status,
+            'duration_ms' => round($duration, 3),
+            'trace_id' => TraceContext::id(),
+            'without_overlapping' => (is_object($task) && ! empty($task->withoutOverlapping)) ? 1 : 0,
+            'environment' => (string) config('app.env'),
+            'release' => (string) config('larabug.project_version', ''),
+            'host' => (string) gethostname(),
+            'ran_at' => gmdate('Y-m-d H:i:s'),
+        ];
+    }
+
+    /**
+     * How long the task ran, from the mark its starting left. The finished event
+     * also carries a runtime, but a start mark works for failed too, which does
+     * not.
+     *
+     * @param  mixed  $task
+     * @param  mixed  $event
+     */
+    protected function duration($task, $event): float
+    {
+        if (is_object($task)) {
+            $key = spl_object_id($task);
+
+            if (isset($this->startedAt[$key])) {
+                $duration = (microtime(true) - $this->startedAt[$key]) * 1000;
+
+                unset($this->startedAt[$key]);
+
+                return $duration;
+            }
+        }
+
+        // A finished event carries the runtime in seconds; fall back to it.
+        if (is_object($event) && isset($event->runtime)) {
+            return (float) $event->runtime * 1000;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * A readable name for a task. A scheduled command has its command string, a
+     * closure has its description or nothing worth a name.
+     *
+     * @param  mixed  $task
+     */
+    protected function taskName($task): string
+    {
+        if (! is_object($task)) {
+            return '';
+        }
+
+        if (method_exists($task, 'getSummaryForDisplay')) {
+            $summary = (string) $task->getSummaryForDisplay();
+
+            if ($summary !== '') {
+                return $this->cleanCommand($summary);
+            }
+        }
+
+        if (! empty($task->description)) {
+            return (string) $task->description;
+        }
+
+        if (! empty($task->command)) {
+            return $this->cleanCommand((string) $task->command);
+        }
+
+        return 'Closure';
+    }
+
+    /**
+     * Strip the php binary and artisan prelude a scheduled command's string
+     * carries, leaving the command as it would be typed.
+     */
+    protected function cleanCommand(string $command): string
+    {
+        if (preg_match("/artisan'?\s+(.*)$/", $command, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return $command;
+    }
+
+    protected function guard(callable $callback): void
+    {
+        try {
+            $callback();
+        } catch (Throwable $e) {
+            // Never let instrumentation surface in the application's own output.
+        }
+    }
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -131,6 +131,35 @@ class Client
     }
 
     /**
+     * @param  array<int, array<string, mixed>>  $records
+     */
+    public function reportScheduledTasks(array $records)
+    {
+        try {
+            return $this->getGuzzleHttpClient()->request('POST', config('larabug.server'), [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$this->login,
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'LaraBug-Package',
+                ],
+                'json' => [
+                    'type' => 'scheduled_tasks_batch',
+                    'project' => $this->project,
+                    'scheduled_tasks' => $records,
+                    'count' => count($records),
+                ],
+                'verify' => config('larabug.verify_ssl'),
+                'timeout' => 5,
+            ]);
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            return $e->getResponse();
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * Report that this app's workers are alive.
      *
      * Its own endpoint rather than a kind of report: this arrives on a schedule

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -104,6 +104,11 @@ class ServiceProvider extends BaseServiceProvider
             $this->app['events']->subscribe(\LaraBug\Console\CommandListeners::class);
         }
 
+        // Scheduled task monitoring, the same context as commands.
+        if (config('larabug.schedule.track_scheduled_tasks', false)) {
+            $this->app['events']->subscribe(\LaraBug\Console\ScheduledTaskListeners::class);
+        }
+
         // The heartbeat only has a job to do where the scheduler runs, which is
         // also the only place it can be registered from.
         if (config('larabug.heartbeat.enabled', true)) {
@@ -332,6 +337,13 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->singleton(\LaraBug\Console\CommandBuffer::class, function ($app) {
             return new \LaraBug\Console\CommandBuffer(
+                $app->make(\LaraBug\Http\Client::class),
+                config('larabug')
+            );
+        });
+
+        $this->app->singleton(\LaraBug\Console\ScheduledTaskBuffer::class, function ($app) {
+            return new \LaraBug\Console\ScheduledTaskBuffer(
                 $app->make(\LaraBug\Http\Client::class),
                 config('larabug')
             );

--- a/tests/ScheduledTaskMonitoringTest.php
+++ b/tests/ScheduledTaskMonitoringTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use LaraBug\Console\CommandBuffer;
+use LaraBug\Console\CommandListeners;
+use LaraBug\Console\ScheduledTaskBuffer;
+use LaraBug\Console\ScheduledTaskListeners;
+
+class ScheduledTaskMonitoringTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // The in-flight counter is static, so an unbalanced test would leak into
+        // the next one.
+        ScheduledTaskListeners::$inFlight = 0;
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_records_a_task_that_ran_with_its_expression_and_duration()
+    {
+        $buffer = $this->taskBuffer();
+        $listeners = new ScheduledTaskListeners($buffer);
+
+        $task = $this->fakeTask('suite:command-ok');
+
+        $listeners->onScheduledTaskStarting($this->taskEvent($task));
+        usleep(1000);
+        $listeners->onScheduledTaskFinished($this->taskEvent($task, 0.1));
+
+        $record = $buffer->records[0];
+        $this->assertSame('suite:command-ok', $record['task']);
+        $this->assertSame('* * * * *', $record['expression']);
+        $this->assertSame('ran', $record['status']);
+        $this->assertGreaterThan(0, $record['duration_ms']);
+        $this->assertNotSame('', $record['trace_id']);
+    }
+
+    /** @test */
+    public function it_records_a_failed_task()
+    {
+        $buffer = $this->taskBuffer();
+        $listeners = new ScheduledTaskListeners($buffer);
+
+        $task = $this->fakeTask('suite:command-fail');
+
+        $listeners->onScheduledTaskStarting($this->taskEvent($task));
+        $listeners->onScheduledTaskFailed($this->taskEvent($task));
+
+        $this->assertSame('failed', $buffer->records[0]['status']);
+    }
+
+    /** @test */
+    public function it_records_a_skipped_task()
+    {
+        $buffer = $this->taskBuffer();
+        $listeners = new ScheduledTaskListeners($buffer);
+
+        // A skipped task never starts, so there is only the skipped event.
+        $listeners->onScheduledTaskSkipped($this->taskEvent($this->fakeTask('suite:skipped')));
+
+        $record = $buffer->records[0];
+        $this->assertSame('skipped', $record['status']);
+        $this->assertSame(0.0, $record['duration_ms']);
+    }
+
+    /** @test */
+    public function a_command_run_while_a_task_is_in_flight_is_attributed_to_the_schedule()
+    {
+        $taskBuffer = $this->taskBuffer();
+        $commandBuffer = $this->commandBuffer();
+
+        $tasks = new ScheduledTaskListeners($taskBuffer);
+        $commands = new CommandListeners($commandBuffer);
+
+        $task = $this->fakeTask('suite:command-ok');
+
+        // The scheduler starts the task, then runs the command in the same
+        // process, then the task finishes.
+        $tasks->onScheduledTaskStarting($this->taskEvent($task));
+
+        $input = $this->fakeInput();
+        $commands->onCommandStarting($this->commandEvent('suite:command-ok', $input));
+        $commands->onCommandFinished($this->commandEvent('suite:command-ok', $input, 0));
+
+        $tasks->onScheduledTaskFinished($this->taskEvent($task, 0.1));
+
+        // Counted once, against the schedule: no command record, one task record.
+        $this->assertCount(0, $commandBuffer->records);
+        $this->assertCount(1, $taskBuffer->records);
+        $this->assertSame('suite:command-ok', $taskBuffer->records[0]['task']);
+    }
+
+    /** @test */
+    public function a_standalone_command_is_still_recorded()
+    {
+        // With no task in flight, the same command is a command as usual.
+        $commandBuffer = $this->commandBuffer();
+        $commands = new CommandListeners($commandBuffer);
+        $input = $this->fakeInput();
+
+        $commands->onCommandStarting($this->commandEvent('suite:command-ok', $input));
+        $commands->onCommandFinished($this->commandEvent('suite:command-ok', $input, 0));
+
+        $this->assertCount(1, $commandBuffer->records);
+    }
+
+    private function taskBuffer(): ScheduledTaskBuffer
+    {
+        return new class extends ScheduledTaskBuffer {
+            /** @var array<int, array<string, mixed>> */
+            public $records = [];
+
+            public function __construct()
+            {
+            }
+
+            public function add(array $record): void
+            {
+                $this->records[] = $record;
+            }
+        };
+    }
+
+    private function commandBuffer(): CommandBuffer
+    {
+        return new class extends CommandBuffer {
+            /** @var array<int, array<string, mixed>> */
+            public $records = [];
+
+            public function __construct()
+            {
+            }
+
+            public function add(array $record): void
+            {
+                $this->records[] = $record;
+            }
+        };
+    }
+
+    private function fakeTask(string $summary, string $expression = '* * * * *'): object
+    {
+        return new class($summary, $expression) {
+            /** @var string */
+            public $expression;
+
+            /** @var string */
+            public $description;
+
+            /** @var string|null */
+            public $command = null;
+
+            /** @var bool */
+            public $withoutOverlapping = false;
+
+            /** @var string */
+            private $summary;
+
+            public function __construct(string $summary, string $expression)
+            {
+                $this->summary = $summary;
+                $this->description = $summary;
+                $this->expression = $expression;
+            }
+
+            public function getSummaryForDisplay(): string
+            {
+                return $this->summary;
+            }
+        };
+    }
+
+    private function taskEvent(object $task, ?float $runtime = null): object
+    {
+        $event = new \stdClass();
+        $event->task = $task;
+
+        if ($runtime !== null) {
+            $event->runtime = $runtime;
+        }
+
+        return $event;
+    }
+
+    private function commandEvent(string $command, object $input, ?int $exitCode = null): object
+    {
+        $event = new \stdClass();
+        $event->command = $command;
+        $event->input = $input;
+
+        if ($exitCode !== null) {
+            $event->exitCode = $exitCode;
+        }
+
+        return $event;
+    }
+
+    private function fakeInput(): object
+    {
+        return new class {
+            /** @return array<string, mixed> */
+            public function getArguments(): array
+            {
+                return [];
+            }
+
+            /** @return array<string, mixed> */
+            public function getOptions(): array
+            {
+                return [];
+            }
+        };
+    }
+}


### PR DESCRIPTION
A ScheduledTaskListeners subscriber hooks the four scheduled task events, resets the trace per task, and records the task, its cron, its status (ran, failed, skipped) and duration into a ScheduledTaskBuffer that ships on shutdown. It keeps an in-flight counter the command listener reads to bow out while a task runs, so a scheduled command run is counted once, against the schedule. Off by default via track_scheduled_tasks.