### PR TITLE
Collect a window of source per stack frame

### DIFF
--- a/config/larabug.php
+++ b/config/larabug.php
@@ -86,6 +86,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Lines near each stack frame
+    |--------------------------------------------------------------------------
+    |
+    | How many lines of source to send around each frame of the stack trace,
+    | on both sides of the frame's own line. Smaller than lines_count on
+    | purpose, since this window is repeated per frame. Values above 25 fall
+    | back to 5.
+    |
+    */
+    'frame_lines_count' => 5,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Frames carrying code
+    |--------------------------------------------------------------------------
+    |
+    | How many frames of the stack trace carry a window of source. Frames
+    | beyond this keep their file, line and function; only the source stops.
+    | Keeps the payload bounded on deep traces.
+    |
+    */
+    'max_code_frames' => 20,
+
+    /*
+    |--------------------------------------------------------------------------
     | Prevent duplicates
     |--------------------------------------------------------------------------
     |

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -136,6 +136,10 @@ class LaraBug
                 }
 
                 $data['executor'] = array_filter($data['executor']);
+
+                // The frames collected above walked the PHP wrapper's trace,
+                // which says nothing about where the JavaScript error was.
+                $data['frames'] = [];
             }
 
             $rawResponse = $this->logError($data);
@@ -285,6 +289,8 @@ class LaraBug
             $data['executor'] = array_filter($data['executor']);
         }
 
+        $data['frames'] = $this->getExceptionFrames($exception);
+
         // Get project version
         $data['project_version'] = config('larabug.project_version', null);
 
@@ -340,6 +346,93 @@ class LaraBug
     public function filterVariables($variables)
     {
         return $this->dataFilter->filterVariables($variables);
+    }
+
+    /**
+     * The stack as structured frames, each with a window of source around its
+     * line, the way Sentry and Flare capture one. The throw site leads, since
+     * getTrace() does not include it, followed by the trace's own frames.
+     *
+     * Bounded twice: frame_lines_count lines of source either side of a
+     * frame's line, and source for at most max_code_frames frames. Deeper
+     * frames keep their file, line and function so the trace stays whole;
+     * only the source windows stop. `error` and `executor` are untouched, so
+     * a server that does not know this field loses nothing.
+     *
+     * @param Throwable $exception
+     * @return array
+     */
+    private function getExceptionFrames(Throwable $exception)
+    {
+        $lineCount = (int) config('larabug.frame_lines_count', 5);
+
+        if ($lineCount > 25) {
+            $lineCount = 5;
+        }
+
+        $maxCodeFrames = (int) config('larabug.max_code_frames', 20);
+
+        $frames = [[
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+            'function' => null,
+            'class' => null,
+            'type' => null,
+        ]];
+
+        foreach ($exception->getTrace() as $trace) {
+            $frames[] = [
+                'file' => $trace['file'] ?? null,
+                'line' => $trace['line'] ?? null,
+                'function' => $trace['function'] ?? null,
+                'class' => $trace['class'] ?? null,
+                'type' => $trace['type'] ?? null,
+            ];
+
+            // A runaway recursion dies hundreds of frames deep; past this
+            // point the frames say nothing the first two hundred did not.
+            if (count($frames) >= 200) {
+                break;
+            }
+        }
+
+        // Files repeat across frames constantly, so each is read once.
+        $fileCache = [];
+        $framesWithCode = 0;
+
+        foreach ($frames as $index => $frame) {
+            $frames[$index]['code'] = [];
+
+            if ($framesWithCode >= $maxCodeFrames || ! $frame['file'] || ! $frame['line']) {
+                continue;
+            }
+
+            if (! array_key_exists($frame['file'], $fileCache)) {
+                $fileCache[$frame['file']] = @file($frame['file']);
+            }
+
+            $lines = $fileCache[$frame['file']];
+
+            if ($lines === false) {
+                continue;
+            }
+
+            $code = [];
+
+            for ($i = -1 * abs($lineCount); $i <= abs($lineCount); $i++) {
+                $code[] = $this->getLineInfo($lines, $frame['line'], $i);
+            }
+
+            // Reindexed, or the filtered gaps make json_encode emit an
+            // object where the server expects a list.
+            $frames[$index]['code'] = array_values(array_filter($code));
+
+            if (count($frames[$index]['code'])) {
+                $framesWithCode++;
+            }
+        }
+
+        return $frames;
     }
 
     /**

--- a/tests/LaraBugTest.php
+++ b/tests/LaraBugTest.php
@@ -149,7 +149,49 @@ class LaraBugTest extends TestCase
         $this->assertArrayHasKey('trace_id', $data);
         $this->assertNotSame('', $data['trace_id']);
 
-        $this->assertCount(14, $data);
+        $this->assertCount(15, $data);
+    }
+
+    /** @test */
+    public function it_collects_a_window_of_source_for_each_frame()
+    {
+        $data = $this->laraBug->getExceptionData(new Exception(
+            'it_collects_a_window_of_source_for_each_frame'
+        ));
+
+        $this->assertIsArray($data['frames']);
+        $this->assertNotEmpty($data['frames']);
+
+        // The throw site leads the trace and points at this file.
+        $this->assertSame(__FILE__, $data['frames'][0]['file']);
+        $this->assertNotEmpty($data['frames'][0]['code']);
+
+        // A code row is the shape executor already uses, and it is a list
+        // rather than a keyed object once encoded.
+        $row = $data['frames'][0]['code'][0];
+        $this->assertArrayHasKey('line_number', $row);
+        $this->assertArrayHasKey('line', $row);
+        $this->assertSame(array_values($data['frames'][0]['code']), $data['frames'][0]['code']);
+    }
+
+    /** @test */
+    public function it_caps_how_many_frames_carry_source()
+    {
+        $this->app['config']['larabug.max_code_frames'] = 1;
+
+        $data = $this->laraBug->getExceptionData(new Exception(
+            'it_caps_how_many_frames_carry_source'
+        ));
+
+        $framesWithCode = count(array_filter($data['frames'], function ($frame) {
+            return ! empty($frame['code']);
+        }));
+
+        $this->assertSame(1, $framesWithCode);
+
+        // The deeper frames still name where they were, only the source stops.
+        $this->assertGreaterThan(1, count($data['frames']));
+        $this->assertNotEmpty($data['frames'][1]['file']);
     }
 
     /** @test */


### PR DESCRIPTION
Adds a structured `frames` array to the exception payload: the throw site first, then each `getTrace()` frame, each carrying a `{line_number, line}` code window read the same way the top-frame `executor` already is.

Bounded on both axes: `frame_lines_count` (default 5) lines either side per frame, `max_code_frames` (default 20) frames carrying source, 200 frames total. Files repeated across frames are read once. The JavaScript path sends an empty `frames`, since the PHP wrapper's trace says nothing about where the JS error was.

`error` and `executor` are unchanged, so older servers ignore the new field and lose nothing.