### PR TITLE
Simplify the package and modernize to the Spatie guidelines

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.4, 8.3, 8.2, 8.1, 8.0, 7.4 ]
-        laravel: [ 13.*, 12.*, 11.*, 10.*, 9.*, 8.*, 7.*, 6.* ]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 13.*, 12.*, 11.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         os: [ ubuntu-latest ]
         include:
@@ -24,103 +24,20 @@ jobs:
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
-          - laravel: 6.*
-            testbench: 4.*
         exclude:
-          # Laravel 6
-          - php: 8.1
-            laravel: 6.*
+          # Laravel 13 needs PHP 8.3
           - php: 8.2
-            laravel: 6.*
-          - php: 8.3
-            laravel: 6.*
-          - php: 8.4
-            laravel: 6.*
+            laravel: 13.*
 
-          # Laravel 7
-          - php: 8.1
-            laravel: 7.*
-          - php: 8.2
-            laravel: 7.*
-          - php: 8.3
-            laravel: 7.*
-          - php: 8.4
-            laravel: 7.*
-
-          # Laravel 8
-          - php: 8.1
-            laravel: 8.*
-          - php: 8.2
-            laravel: 8.*
-          - php: 8.3
-            laravel: 8.*
-          - php: 8.4
-            laravel: 8.*
-
-          # Laravel 9
-          - php: 7.4
-            laravel: 9.*
-          - php: 8.3
-            laravel: 9.*
-          - php: 8.4
-            laravel: 9.*
-
-          # Laravel 10
-          - php: 7.4
-            laravel: 10.*
-          - php: 8.0
-            laravel: 10.*
-
-          # Laravel 11+
-          - php: 7.4
-            laravel: 11.*
-          - php: 8.0
-            laravel: 11.*
-          - php: 8.1
-            laravel: 11.*
-
-          # Laravel 11 prefer-lowest (incompatible with PHP 8.2+)
-          - php: 8.2
-            laravel: 11.*
+          # Laravel 11's lowest dependency set does not resolve on PHP 8.2+
+          - laravel: 11.*
             dependency-version: prefer-lowest
-          - php: 8.3
-            laravel: 11.*
-            dependency-version: prefer-lowest
-          - php: 8.4
-            laravel: 11.*
-            dependency-version: prefer-lowest
-
-          # Laravel 12+
-          - php: 7.4
-            laravel: 12.*
-          - php: 8.0
-            laravel: 12.*
-          - php: 8.1
-            laravel: 12.*
-
-          # Laravel 13+
-          - php: 7.4
-            laravel: 13.*
-          - php: 8.0
-            laravel: 13.*
-          - php: 8.1
-            laravel: 13.*
-          - php: 8.2
-            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -132,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ $finder = Symfony\Component\Finder\Finder::create()
 
 return (new PhpCsFixer\Config)
     ->setRules([
-        '@PSR2' => true,
+        '@PSR12' => true,
         'array_syntax' => true,
         'ordered_imports' => ['sort_algorithm' => 'length'],
         'no_unused_imports' => true,

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,22 @@
 {
     "name": "larabug/larabug",
-    "description": "Laravel 6.x/7.x/8.x/9.x/10.x/11.x/12.x/13.x bug notifier",
+    "description": "Laravel 11.x/12.x/13.x bug notifier",
     "keywords": [
         "laravel",
         "log",
         "error"
     ],
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.2 || ^8.3 || ^8.4",
-        "guzzlehttp/guzzle": "^6.0.2 || ^7.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "nesbot/carbon": "^2.62.1 || ^3.0"
+        "php": "^8.2",
+        "guzzlehttp/guzzle": "^7.8",
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+        "nesbot/carbon": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.4",
-        "mockery/mockery": "^1.3.3 || ^1.4.2",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
-        "phpunit/phpunit": "^8.5.23 || ^9.5.12 || ^10.0.9 || ^11.0"
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -41,9 +41,6 @@
             "providers": [
                 "LaraBug\\ServiceProvider"
             ]
-        },
-        "branch-alias": {
-            "dev-feature/queue-monitoring": "3.3.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/config/larabug.php
+++ b/config/larabug.php
@@ -519,7 +519,7 @@ return [
         | Dynamic Batching (Automatic Load-Based)
         |--------------------------------------------------------------------------
         |
-        | Batching automatically activates when job dispatch rate exceeds a 
+        | Batching automatically activates when job dispatch rate exceeds a
         | threshold. During low traffic, events are sent immediately (no delay).
         | During high traffic, events are buffered and sent in batches.
         |
@@ -623,7 +623,7 @@ return [
         | 0.5 = track 50% of successful jobs
         | 0.1 = track 10% of successful jobs
         | 0.0 = don't track successful jobs
-        | 
+        |
         | Note: Failures are ALWAYS tracked at 100% regardless of this setting
         */
         'sample_rate' => env('LB_SAMPLE_RATE', 1.0),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
          backupGlobals="false"
          colors="true"
          processIsolation="false"
          stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
     <testsuites>
         <testsuite name="LaraBug Test Suite">
             <directory>tests</directory>

--- a/src/Commands/HeartbeatCommand.php
+++ b/src/Commands/HeartbeatCommand.php
@@ -2,9 +2,9 @@
 
 namespace LaraBug\Commands;
 
-use Illuminate\Console\Command;
 use LaraBug\Http\Client;
 use LaraBug\Queue\Heartbeat;
+use Illuminate\Console\Command;
 
 class HeartbeatCommand extends Command
 {
@@ -12,7 +12,7 @@ class HeartbeatCommand extends Command
 
     protected $description = 'Report that this app\'s queue workers are alive';
 
-    public function handle()
+    public function handle(): int
     {
         $payload = app(Heartbeat::class)->payload();
 
@@ -22,17 +22,18 @@ class HeartbeatCommand extends Command
             return 0;
         }
 
-        if (! in_array(config('app.env'), (array) config('larabug.environments'), true)) {
-            $this->info('[LaraBug] Environment ('.config('app.env').') is not configured to report, nothing sent');
+        $environment = config('app.env');
+
+        if (! in_array($environment, (array) config('larabug.environments'), true)) {
+            $this->info("[LaraBug] Environment ({$environment}) is not configured to report, nothing sent");
 
             return 0;
         }
 
         $response = app(Client::class)->heartbeat($payload);
 
-        // A heartbeat is worth nothing if sending it can break the scheduler, so
-        // a failure is reported and swallowed. The panel's own view of a missing
-        // heartbeat is the same either way: nothing arrived.
+        // A heartbeat is worth nothing if sending it can break the scheduler,
+        // so a failure is reported and swallowed: every path exits 0.
         if ($response === null) {
             $this->error('✗ [LaraBug] Could not reach the server');
 
@@ -47,7 +48,7 @@ class HeartbeatCommand extends Command
             return 0;
         }
 
-        $this->error('✗ [LaraBug] Server answered '.$status);
+        $this->error("✗ [LaraBug] Server answered {$status}");
 
         return 0;
     }

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -2,8 +2,8 @@
 
 namespace LaraBug\Commands;
 
-use Illuminate\Console\Command;
 use LaraBug\Http\Client;
+use Illuminate\Console\Command;
 use LaraBug\Scanners\ComposerLockScanner;
 
 class ScanCommand extends Command
@@ -14,17 +14,12 @@ class ScanCommand extends Command
 
     protected $description = 'Scan this app\'s composer.lock for known CVEs via LaraBug.';
 
-    /**
-     * Exit codes are the literal 0, 1 and 2 rather than Command::SUCCESS,
-     * FAILURE and INVALID. Those constants only exist from Laravel 8, and this
-     * package still supports 6 and 7, where they are a fatal "undefined class
-     * constant" the moment the command returns.
-     */
     public function handle(Client $client, ComposerLockScanner $scanner): int
     {
         if (! config('larabug.cve.enabled', true)) {
             $this->warn('CVE scanning is disabled. Remove LB_CVE_ENABLED=false to enable it.');
-            return 2;
+
+            return self::INVALID;
         }
 
         $lockPath = $this->option('lock') ?: config('larabug.cve.lock_path');
@@ -34,11 +29,16 @@ class ScanCommand extends Command
         $payload = $scanner->scan($lockPath, $includeDev, $environment);
 
         if ($payload === null) {
-            $this->error('Could not read composer.lock at ' . ($lockPath ?: base_path('composer.lock')));
-            return 1;
+            $resolvedLockPath = $lockPath ?: base_path('composer.lock');
+
+            $this->error("Could not read composer.lock at {$resolvedLockPath}");
+
+            return self::FAILURE;
         }
 
-        $this->info('Scanning ' . count($payload['packages']) . ' packages against LaraBug CVE database...');
+        $packageCount = count($payload['packages']);
+
+        $this->info("Scanning {$packageCount} packages against LaraBug CVE database...");
 
         $response = $client->report([
             'type' => 'cve_scan',
@@ -47,7 +47,8 @@ class ScanCommand extends Command
 
         if ($response === null) {
             $this->error('Failed to reach LaraBug. Check your network and configuration.');
-            return 1;
+
+            return self::FAILURE;
         }
 
         $status = method_exists($response, 'getStatusCode') ? $response->getStatusCode() : 0;
@@ -55,28 +56,35 @@ class ScanCommand extends Command
 
         if ($status === 403) {
             $this->error('CVE scanning is not enabled on this project in LaraBug. Enable it on the project settings page.');
-            return 1;
+
+            return self::FAILURE;
         }
 
         if ($status >= 400) {
             $this->error("LaraBug returned HTTP {$status}: {$body}");
-            return 1;
+
+            return self::FAILURE;
         }
 
         $json = json_decode($body, true);
 
         if (isset($json['skipped']) && $json['skipped'] === 'unchanged') {
             $this->info('composer.lock unchanged since last scan — skipped.');
-            return 0;
+
+            return self::SUCCESS;
         }
 
-        if (isset($json['queued']) && $json['queued']) {
-            $this->info('Scan queued. Snapshot ID: ' . ($json['snapshot_id'] ?? 'unknown'));
+        if (! empty($json['queued'])) {
+            $snapshotId = $json['snapshot_id'] ?? 'unknown';
+
+            $this->info("Scan queued. Snapshot ID: {$snapshotId}");
             $this->line('Results will appear in your Issues list once the scan completes.');
-            return 0;
+
+            return self::SUCCESS;
         }
 
         $this->info('Scan accepted.');
-        return 0;
+
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/TestCommand.php
+++ b/src/Commands/TestCommand.php
@@ -3,6 +3,7 @@
 namespace LaraBug\Commands;
 
 use Exception;
+use LaraBug\LaraBug;
 use Illuminate\Console\Command;
 
 class TestCommand extends Command
@@ -11,7 +12,7 @@ class TestCommand extends Command
 
     protected $description = 'Generate a test exception and send it to larabug';
 
-    public function handle()
+    public function handle(): void
     {
         try {
             /** @var LaraBug $laraBug */
@@ -30,10 +31,12 @@ class TestCommand extends Command
                 $this->info('More information on setting your project key: https://www.larabug.com/docs/how-to-use/installation');
             }
 
-            if (in_array(config('app.env'), config('larabug.environments'))) {
-                $this->info('✓ [Larabug] Correct environment found (' . config('app.env') . ')');
+            $environment = config('app.env');
+
+            if (in_array($environment, config('larabug.environments'))) {
+                $this->info("✓ [Larabug] Correct environment found ({$environment})");
             } else {
-                $this->error('✗ [LaraBug] Environment (' . config('app.env') . ') not allowed to send errors to LaraBug, set this in your config');
+                $this->error("✗ [LaraBug] Environment ({$environment}) not allowed to send errors to LaraBug, set this in your config");
                 $this->info('More information about environment configuration: https://www.larabug.com/docs/how-to-use/installation');
             }
 
@@ -42,13 +45,13 @@ class TestCommand extends Command
             );
 
             if (isset($response->id)) {
-                $this->info('✓ [LaraBug] Sent exception to LaraBug with ID: '.$response->id);
-            } elseif (is_null($response)) {
+                $this->info("✓ [LaraBug] Sent exception to LaraBug with ID: {$response->id}");
+            } elseif ($response === null) {
                 $this->info('✓ [LaraBug] Sent exception to LaraBug!');
             } else {
                 $this->error('✗ [LaraBug] Failed to send exception to LaraBug');
             }
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             $this->error("✗ [LaraBug] {$ex->getMessage()}");
         }
     }

--- a/src/Concerns/Trackable.php
+++ b/src/Concerns/Trackable.php
@@ -16,25 +16,16 @@ namespace LaraBug\Concerns;
  */
 trait Trackable
 {
-    /**
-     * Determine if this job should be tracked by LaraBug
-     */
     public function shouldTrackInLaraBug(): bool
     {
         return true;
     }
 
-    /**
-     * Get custom tags for this job (optional)
-     */
     public function larabugTags(): array
     {
         return [];
     }
 
-    /**
-     * Get custom metadata for this job (optional)
-     */
     public function larabugMetadata(): array
     {
         return [];

--- a/src/Console/CommandBuffer.php
+++ b/src/Console/CommandBuffer.php
@@ -3,39 +3,36 @@
 namespace LaraBug\Console;
 
 use Countable;
-use LaraBug\Http\Client;
 use Throwable;
+use LaraBug\Http\Client;
 
 /**
  * Batches finished command records.
  *
  * The console counterpart to RequestBuffer. A console process runs one command
  * and then exits, so the flush happens on shutdown as well as on size: without
- * it the record of the command that just finished would be lost at the moment it
- * completed. A long-running worker that this package does not ignore would flush
- * on size instead, but those are on the ignore list precisely because they never
- * finish.
+ * it the record of the command that just finished would be lost at the moment
+ * it completed.
  */
 class CommandBuffer implements Countable
 {
     /** @var array<int, array<string, mixed>> */
-    protected $buffer = [];
+    protected array $buffer = [];
 
-    /** @var Client */
-    protected $client;
+    protected readonly Client $client;
 
     /** @var array<string, mixed> */
-    protected $config;
+    protected readonly array $config;
 
-    /** @var int */
-    protected $batchSize;
+    protected readonly int $batchSize;
 
-    /** @var int */
-    protected $maxRetries;
+    protected readonly int $maxRetries;
 
-    /** @var bool */
-    protected $shutdownRegistered = false;
+    protected bool $shutdownRegistered = false;
 
+    /**
+     * @param  array<string, mixed>  $config
+     */
     public function __construct(Client $client, array $config)
     {
         $this->client = $client;
@@ -77,7 +74,7 @@ class CommandBuffer implements Countable
     {
         try {
             $this->client->reportCommands($records);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             if ($attempt <= $this->maxRetries) {
                 usleep(100000 * $attempt);
 
@@ -99,9 +96,7 @@ class CommandBuffer implements Countable
 
         $this->shutdownRegistered = true;
 
-        register_shutdown_function(function () {
-            $this->flush();
-        });
+        register_shutdown_function($this->flush(...));
     }
 
     public function count(): int

--- a/src/Console/CommandListeners.php
+++ b/src/Console/CommandListeners.php
@@ -2,61 +2,50 @@
 
 namespace LaraBug\Console;
 
-use Illuminate\Contracts\Events\Dispatcher;
-use LaraBug\Requests\TraceContext;
 use Throwable;
+use LaraBug\Requests\TraceContext;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
 
 /**
  * The events that fill in a command record.
  *
- * Subscribed only when command tracking is on. A command is its own execution
- * context, neither a request nor a job, so it carries its own trace and its own
- * buffer. The handlers are stacked rather than keyed on a single current
- * command, because a command can call another (Artisan::call), and a finish has
- * to match the start it belongs to.
+ * Subscribed only when command tracking is on. The handlers are stacked rather
+ * than keyed on a single current command, because a command can call another
+ * (Artisan::call) and a finish has to match the start it belongs to.
  */
 class CommandListeners
 {
-    /** @var CommandBuffer */
-    protected $buffer;
-
     /** @var array<int, array<string, mixed>|null> The commands in flight. */
-    protected $stack = [];
+    protected array $stack = [];
 
-    public function __construct(CommandBuffer $buffer)
+    public function __construct(protected readonly CommandBuffer $buffer)
     {
-        $this->buffer = $buffer;
     }
 
-    /**
-     * Registered one at a time rather than by returning a map, the same as the
-     * request listeners: this package supports Laravel 6, whose dispatcher does
-     * not read a subscribe map.
-     */
     public function subscribe(Dispatcher $events): void
     {
-        $events->listen('Illuminate\Console\Events\CommandStarting', [$this, 'onCommandStarting']);
-        $events->listen('Illuminate\Console\Events\CommandFinished', [$this, 'onCommandFinished']);
+        $events->listen(CommandStarting::class, $this->onCommandStarting(...));
+        $events->listen(CommandFinished::class, $this->onCommandFinished(...));
     }
 
-    public function onCommandStarting($event): void
+    public function onCommandStarting(object $event): void
     {
         $this->guard(function () use ($event) {
             $command = (string) ($event->command ?? '');
 
-            // A command run by the scheduler in the same process belongs to the
-            // schedule, not to commands: the scheduled task listener counts it,
-            // and counting it here too would double it. A null frame keeps the
-            // finish handler's stack balanced without recording it.
+            // A command the scheduler runs in-process belongs to the schedule,
+            // not to commands; a null frame keeps the finish handler's stack
+            // balanced without recording it twice.
             if ($command === '' || $this->ignored($command) || ScheduledTaskListeners::$inFlight > 0) {
                 $this->stack[] = null;
 
                 return;
             }
 
-            // Each command is its own unit of work, so each gets its own trace,
-            // the same as a queued job. A console process that runs several in a
-            // row would otherwise stamp them all with the first one's id.
+            // Each command is its own unit of work, so it gets its own trace,
+            // the same as a queued job.
             TraceContext::reset();
 
             $this->stack[] = [
@@ -68,7 +57,7 @@ class CommandListeners
         });
     }
 
-    public function onCommandFinished($event): void
+    public function onCommandFinished(object $event): void
     {
         $this->guard(function () use ($event) {
             if ($this->stack === []) {
@@ -87,8 +76,7 @@ class CommandListeners
                 'duration_ms' => round((microtime(true) - $frame['start']) * 1000, 3),
                 'memory_peak_kb' => (int) round(memory_get_peak_usage(true) / 1024),
 
-                // The same id any log lines and exceptions from this command
-                // carry, which is the whole reason to keep it.
+                // The same id this command's log lines and exceptions carry.
                 'trace_id' => $frame['trace_id'],
 
                 'arguments' => $this->arguments($event->input ?? null),
@@ -113,20 +101,18 @@ class CommandListeners
     }
 
     /**
-     * The arguments and options a command was given, as JSON, with the sensitive
-     * ones replaced by a marker. Read off the input and guarded: the input is a
-     * Symfony contract whose getters throw when the definition is not bound, and
-     * a command that could not be detailed is still worth counting.
-     *
-     * @param  mixed  $input
+     * The arguments and options a command was given, as JSON, with sensitive
+     * ones replaced by a marker. Guarded because the Symfony input getters
+     * throw when the definition is not bound, and a command that could not be
+     * detailed is still worth counting.
      */
-    protected function arguments($input): string
+    protected function arguments(mixed $input): string
     {
         if (! is_object($input)) {
             return '';
         }
 
-        $redact = array_map('strtolower', (array) config('larabug.commands.redact', []));
+        $redact = array_map(strtolower(...), (array) config('larabug.commands.redact', []));
 
         $bag = [];
 
@@ -147,7 +133,7 @@ class CommandListeners
                     $bag['options'][$name] = $this->redactValue((string) $name, $value, $redact);
                 }
             }
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return '';
         }
 
@@ -155,16 +141,14 @@ class CommandListeners
     }
 
     /**
-     * @param  mixed  $value
      * @param  array<int, string>  $redact  lowercased needles
-     * @return mixed
      */
-    protected function redactValue(string $name, $value, array $redact)
+    protected function redactValue(string $name, mixed $value, array $redact): mixed
     {
         $lower = strtolower($name);
 
         foreach ($redact as $needle) {
-            if ($needle !== '' && strpos($lower, $needle) !== false) {
+            if ($needle !== '' && str_contains($lower, $needle)) {
                 return '[redacted]';
             }
         }
@@ -176,7 +160,7 @@ class CommandListeners
     {
         try {
             $callback();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             // Never let instrumentation surface in the application's own output.
         }
     }

--- a/src/Console/ScheduledTaskBuffer.php
+++ b/src/Console/ScheduledTaskBuffer.php
@@ -3,37 +3,37 @@
 namespace LaraBug\Console;
 
 use Countable;
-use LaraBug\Http\Client;
 use Throwable;
+use LaraBug\Http\Client;
 
 /**
  * Batches finished scheduled task records.
  *
- * Its own buffer rather than the command one, because the two are told apart on
- * the way out by which sender they use: a task ships as a scheduled_tasks_batch,
- * a command as a commands_batch. The scheduler runs inside a single schedule:run
- * process, so this flushes on shutdown like the command buffer.
+ * Its own buffer rather than the command one, because the two are told apart
+ * on the way out by which sender they use: a task ships as a
+ * scheduled_tasks_batch, a command as a commands_batch. Flushes on shutdown
+ * like the command buffer, since the scheduler runs inside a single
+ * schedule:run process.
  */
 class ScheduledTaskBuffer implements Countable
 {
     /** @var array<int, array<string, mixed>> */
-    protected $buffer = [];
+    protected array $buffer = [];
 
-    /** @var Client */
-    protected $client;
+    protected readonly Client $client;
 
     /** @var array<string, mixed> */
-    protected $config;
+    protected readonly array $config;
 
-    /** @var int */
-    protected $batchSize;
+    protected readonly int $batchSize;
 
-    /** @var int */
-    protected $maxRetries;
+    protected readonly int $maxRetries;
 
-    /** @var bool */
-    protected $shutdownRegistered = false;
+    protected bool $shutdownRegistered = false;
 
+    /**
+     * @param  array<string, mixed>  $config
+     */
     public function __construct(Client $client, array $config)
     {
         $this->client = $client;
@@ -75,7 +75,7 @@ class ScheduledTaskBuffer implements Countable
     {
         try {
             $this->client->reportScheduledTasks($records);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             if ($attempt <= $this->maxRetries) {
                 usleep(100000 * $attempt);
 
@@ -97,9 +97,7 @@ class ScheduledTaskBuffer implements Countable
 
         $this->shutdownRegistered = true;
 
-        register_shutdown_function(function () {
-            $this->flush();
-        });
+        register_shutdown_function($this->flush(...));
     }
 
     public function count(): int

--- a/src/Console/ScheduledTaskListeners.php
+++ b/src/Console/ScheduledTaskListeners.php
@@ -2,55 +2,52 @@
 
 namespace LaraBug\Console;
 
-use Illuminate\Contracts\Events\Dispatcher;
-use LaraBug\Requests\TraceContext;
 use Throwable;
+use LaraBug\Requests\TraceContext;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskSkipped;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
 
 /**
  * The events that fill in a scheduled task record.
  *
- * Subscribed only when scheduled task tracking is on. A scheduled task is its
- * own execution context, and a scheduled command run is attributed here rather
- * than to commands: the in-flight counter this keeps is what the command
- * listener reads to bow out while a task is running, so the run is counted once.
+ * Subscribed only when scheduled task tracking is on. The in-flight counter it
+ * keeps is what the command listener reads to bow out while a task is running,
+ * so a scheduled command run is counted once, against the schedule.
  */
 class ScheduledTaskListeners
 {
     /**
-     * How many scheduled tasks are running right now. The command listener reads
-     * this to attribute a scheduled command run to the schedule rather than to
-     * commands. A counter, not a flag, because a task can, in principle, run
-     * inside another.
-     *
-     * @var int
+     * How many scheduled tasks are running right now. The command listener
+     * reads this to attribute a scheduled command run to the schedule rather
+     * than to commands. A counter, not a flag, because a task can, in
+     * principle, run inside another.
      */
-    public static $inFlight = 0;
+    public static int $inFlight = 0;
 
-    /** @var ScheduledTaskBuffer */
-    protected $buffer;
+    /** @var array<int, float> Start marks, keyed by task object id. */
+    protected array $startedAt = [];
 
-    /** @var array<int, float> Start marks, keyed by the task object. */
-    protected $startedAt = [];
-
-    public function __construct(ScheduledTaskBuffer $buffer)
+    public function __construct(protected readonly ScheduledTaskBuffer $buffer)
     {
-        $this->buffer = $buffer;
     }
 
     public function subscribe(Dispatcher $events): void
     {
-        $events->listen('Illuminate\Console\Events\ScheduledTaskStarting', [$this, 'onScheduledTaskStarting']);
-        $events->listen('Illuminate\Console\Events\ScheduledTaskFinished', [$this, 'onScheduledTaskFinished']);
-        $events->listen('Illuminate\Console\Events\ScheduledTaskFailed', [$this, 'onScheduledTaskFailed']);
-        $events->listen('Illuminate\Console\Events\ScheduledTaskSkipped', [$this, 'onScheduledTaskSkipped']);
+        $events->listen(ScheduledTaskStarting::class, $this->onScheduledTaskStarting(...));
+        $events->listen(ScheduledTaskFinished::class, $this->onScheduledTaskFinished(...));
+        $events->listen(ScheduledTaskFailed::class, $this->onScheduledTaskFailed(...));
+        $events->listen(ScheduledTaskSkipped::class, $this->onScheduledTaskSkipped(...));
     }
 
-    public function onScheduledTaskStarting($event): void
+    public function onScheduledTaskStarting(object $event): void
     {
         $this->guard(function () use ($event) {
             self::$inFlight++;
 
-            // Each task is its own unit of work, so each gets its own trace, the
+            // Each task is its own unit of work, so it gets its own trace, the
             // same as a queued job or a command.
             TraceContext::reset();
 
@@ -62,17 +59,17 @@ class ScheduledTaskListeners
         });
     }
 
-    public function onScheduledTaskFinished($event): void
+    public function onScheduledTaskFinished(object $event): void
     {
         $this->record($event, 'ran');
     }
 
-    public function onScheduledTaskFailed($event): void
+    public function onScheduledTaskFailed(object $event): void
     {
         $this->record($event, 'failed');
     }
 
-    public function onScheduledTaskSkipped($event): void
+    public function onScheduledTaskSkipped(object $event): void
     {
         // A skipped task never started, so the in-flight counter was not raised
         // for it and nothing needs releasing here.
@@ -81,10 +78,7 @@ class ScheduledTaskListeners
         });
     }
 
-    /**
-     * @param  mixed  $event
-     */
-    protected function record($event, string $status): void
+    protected function record(object $event, string $status): void
     {
         $this->guard(function () use ($event, $status) {
             if (self::$inFlight > 0) {
@@ -99,10 +93,9 @@ class ScheduledTaskListeners
     }
 
     /**
-     * @param  mixed  $task
      * @return array<string, mixed>
      */
-    protected function toRecord($task, string $status, float $duration): array
+    protected function toRecord(mixed $task, string $status, float $duration): array
     {
         return [
             'task' => $this->taskName($task),
@@ -119,14 +112,11 @@ class ScheduledTaskListeners
     }
 
     /**
-     * How long the task ran, from the mark its starting left. The finished event
-     * also carries a runtime, but a start mark works for failed too, which does
-     * not.
-     *
-     * @param  mixed  $task
-     * @param  mixed  $event
+     * How long the task ran, from the mark its starting left. The finished
+     * event also carries a runtime, but a start mark works for failed too,
+     * which does not.
      */
-    protected function duration($task, $event): float
+    protected function duration(mixed $task, object $event): float
     {
         if (is_object($task)) {
             $key = spl_object_id($task);
@@ -141,7 +131,7 @@ class ScheduledTaskListeners
         }
 
         // A finished event carries the runtime in seconds; fall back to it.
-        if (is_object($event) && isset($event->runtime)) {
+        if (isset($event->runtime)) {
             return (float) $event->runtime * 1000;
         }
 
@@ -149,12 +139,10 @@ class ScheduledTaskListeners
     }
 
     /**
-     * A readable name for a task. A scheduled command has its command string, a
-     * closure has its description or nothing worth a name.
-     *
-     * @param  mixed  $task
+     * A readable name for a task: a scheduled command has its command string,
+     * a closure its description or nothing worth a name.
      */
-    protected function taskName($task): string
+    protected function taskName(mixed $task): string
     {
         if (! is_object($task)) {
             return '';
@@ -196,7 +184,7 @@ class ScheduledTaskListeners
     {
         try {
             $callback();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             // Never let instrumentation surface in the application's own output.
         }
     }

--- a/src/Cve/RequestTrigger.php
+++ b/src/Cve/RequestTrigger.php
@@ -2,48 +2,38 @@
 
 namespace LaraBug\Cve;
 
-use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use LaraBug\Http\Client;
 use LaraBug\Scanners\ComposerLockScanner;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
 /**
  * Request-piggyback trigger for CVE scans.
  *
  * Wired up via `app()->terminating(...)` from the ServiceProvider, so it runs
  * after the response is sent to the user — zero perceptible latency. Cached
- * heavily so the hot path is a single Cache::get on most requests:
- *
- *   - The lockfile hash is computed once per process (it doesn't change at runtime).
- *   - The "last sent hash" is cached for `request_throttle_hours`. A request only
- *     does work when (a) the hash changes (deploy), or (b) the throttle expires.
- *   - A short-lived cache lock prevents a thundering herd of concurrent requests
- *     all triggering scans simultaneously.
+ * heavily so the hot path is a single Cache::get on most requests: the
+ * lockfile payload is memoized per process, the last sent hash is cached for
+ * `request_throttle_hours`, and a short-lived cache lock prevents a thundering
+ * herd of concurrent requests all triggering scans simultaneously.
  */
 class RequestTrigger
 {
-    protected const CACHE_KEY_HASH = 'larabug.cve.last_sent_hash';
-    protected const CACHE_KEY_TIMESTAMP = 'larabug.cve.last_sent_at';
-    protected const CACHE_KEY_BACKOFF = 'larabug.cve.backoff_until';
-    protected const LOCK_KEY = 'larabug.cve.trigger_lock';
-    protected const LOCK_SECONDS = 60;
-    protected const BACKOFF_SECONDS = 3600;
-
-    /** Memoized lockfile payload for this process. */
+    /** @var array<string, mixed>|null Memoized lockfile payload for this process. */
     protected static ?array $cachedPayload = null;
+
     protected static bool $alreadyFired = false;
 
-    protected CacheRepository $cache;
-    protected ComposerLockScanner $scanner;
-    protected Client $client;
+    private string $lastSentHashCacheKey = 'larabug.cve.last_sent_hash';
 
-    // Written out rather than promoted: promotion and the trailing comma in a
-    // parameter list are both PHP 8.0+, and this package still supports 7.4.
-    // Typed properties are fine, those landed in 7.4.
-    public function __construct(CacheRepository $cache, ComposerLockScanner $scanner, Client $client)
-    {
-        $this->cache = $cache;
-        $this->scanner = $scanner;
-        $this->client = $client;
+    private string $lastSentAtCacheKey = 'larabug.cve.last_sent_at';
+
+    private string $backoffCacheKey = 'larabug.cve.backoff_until';
+
+    public function __construct(
+        protected readonly CacheRepository $cache,
+        protected readonly ComposerLockScanner $scanner,
+        protected readonly Client $client,
+    ) {
     }
 
     public function maybeTrigger(): void
@@ -53,6 +43,7 @@ class RequestTrigger
         }
 
         $trigger = strtolower((string) config('larabug.cve.trigger', 'both'));
+
         if (! in_array($trigger, ['request', 'both'], true)) {
             return;
         }
@@ -61,9 +52,11 @@ class RequestTrigger
         if (self::$alreadyFired) {
             return;
         }
+
         self::$alreadyFired = true;
 
         $payload = $this->payload();
+
         if ($payload === null) {
             return;
         }
@@ -73,7 +66,7 @@ class RequestTrigger
         }
 
         $lock = method_exists($this->cache, 'lock')
-            ? $this->cache->lock(self::LOCK_KEY, self::LOCK_SECONDS)
+            ? $this->cache->lock('larabug.cve.trigger_lock', 60)
             : null;
 
         if ($lock && ! $lock->get()) {
@@ -84,10 +77,13 @@ class RequestTrigger
         try {
             $this->send($payload);
         } finally {
-            optional($lock)->release();
+            $lock?->release();
         }
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
     protected function payload(): ?array
     {
         if (self::$cachedPayload !== null) {
@@ -112,22 +108,25 @@ class RequestTrigger
         // The server has told us it does not want these yet. Without this the
         // scan is enabled by default but the project is not, so every single
         // request would post the lockfile and collect another 403.
-        if ($this->cache->get(self::CACHE_KEY_BACKOFF)) {
+        if ($this->cache->get($this->backoffCacheKey)) {
             return false;
         }
 
-        $lastHash = $this->cache->get(self::CACHE_KEY_HASH);
+        $lastHash = $this->cache->get($this->lastSentHashCacheKey);
 
         if ($lastHash !== $currentHash) {
             return true;
         }
 
-        $lastSentAt = (int) $this->cache->get(self::CACHE_KEY_TIMESTAMP, 0);
+        $lastSentAt = (int) $this->cache->get($this->lastSentAtCacheKey, 0);
         $throttleSeconds = max(1, (int) config('larabug.cve.request_throttle_hours', 24)) * 3600;
 
         return (time() - $lastSentAt) >= $throttleSeconds;
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     protected function send(array $payload): void
     {
         $response = $this->client->report([
@@ -148,18 +147,19 @@ class RequestTrigger
         // Only 2xx and "skipped" count as the scan having landed.
         if (($status >= 200 && $status < 300) || $unchanged) {
             $ttl = max(1, (int) config('larabug.cve.request_throttle_hours', 24)) * 3600;
-            $this->cache->put(self::CACHE_KEY_HASH, $payload['content_hash'], $ttl);
-            $this->cache->put(self::CACHE_KEY_TIMESTAMP, time(), $ttl);
+            $this->cache->put($this->lastSentHashCacheKey, $payload['content_hash'], $ttl);
+            $this->cache->put($this->lastSentAtCacheKey, time(), $ttl);
 
             return;
         }
 
         // 403 is the server saying this project has not turned CVE scanning on.
         // That is a settled answer, not a blip, so back off rather than asking
-        // again on the very next request. Short enough that enabling it in the
-        // panel starts working without waiting out the full throttle window.
+        // again on the very next request. An hour is short enough that enabling
+        // it in the panel starts working without waiting out the full throttle
+        // window.
         if ($status === 403) {
-            $this->cache->put(self::CACHE_KEY_BACKOFF, time(), self::BACKOFF_SECONDS);
+            $this->cache->put($this->backoffCacheKey, time(), 3600);
         }
 
         // Anything else (a 5xx, a timeout) leaves the cache untouched, so the

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -6,31 +6,24 @@ use LaraBug\Http\Client;
 use LaraBug\Fakes\LaraBugFake;
 
 /**
- * @method static \LaraBug\LaraBug context(array $context)
- * @method static \LaraBug\LaraBug clearContext()
- * @method static void assertSent($throwable, $callback = null)
+ * @method static void context(array $context)
+ * @method static void clearContext()
+ * @method static void assertSent(mixed $throwable, ?callable $callback = null)
  * @method static void assertRequestsSent(int $count)
- * @method static void assertNotSent($throwable, $callback = null)
+ * @method static void assertNotSent(mixed $throwable, ?callable $callback = null)
  * @method static void assertNothingSent()
  */
 class Facade extends \Illuminate\Support\Facades\Facade
 {
     /**
      * Replace the bound instance with a fake.
-     *
-     * @return void
      */
-    public static function fake()
+    public static function fake(): void
     {
         static::swap(new LaraBugFake(new Client('login_key', 'project_key')));
     }
 
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'larabug';
     }

--- a/src/Fakes/LaraBugFake.php
+++ b/src/Fakes/LaraBugFake.php
@@ -2,66 +2,49 @@
 
 namespace LaraBug\Fakes;
 
+use Throwable;
+use LaraBug\LaraBug;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class LaraBugFake extends \LaraBug\LaraBug
+class LaraBugFake extends LaraBug
 {
-    /** @var array */
-    public $exceptions = [];
+    /** @var array<class-string, array<int, Throwable>> */
+    public array $exceptions = [];
 
-    /**
-     * @param int $expectedCount
-     */
-    public function assertRequestsSent(int $expectedCount)
+    public function assertRequestsSent(int $expectedCount): void
     {
         PHPUnit::assertCount($expectedCount, $this->exceptions);
     }
 
-    /**
-     * @param mixed $throwable
-     * @param callable|null $callback
-     */
-    public function assertNotSent($throwable, $callback = null)
+    public function assertNotSent(mixed $throwable, ?callable $callback = null): void
     {
-        $collect = collect($this->exceptions[$throwable] ?? []);
+        $callback = $callback ?: fn () => true;
 
-        $callback = $callback ?: function () {
-            return true;
-        };
-
-        $filtered = $collect->filter(function ($arguments) use ($callback) {
-            return $callback($arguments);
-        });
+        $filtered = collect($this->exceptions[$throwable] ?? [])
+            ->filter(fn ($arguments) => $callback($arguments));
 
         PHPUnit::assertTrue($filtered->count() == 0);
     }
 
-    public function assertNothingSent()
+    public function assertNothingSent(): void
     {
         PHPUnit::assertCount(0, $this->exceptions);
     }
 
-    /**
-     * @param mixed $throwable
-     * @param callable|null $callback
-     */
-    public function assertSent($throwable, $callback = null)
+    public function assertSent(mixed $throwable, ?callable $callback = null): void
     {
-        $collect = collect($this->exceptions[$throwable] ?? []);
+        $callback = $callback ?: fn () => true;
 
-        $callback = $callback ?: function () {
-            return true;
-        };
-
-        $filtered = $collect->filter(function ($arguments) use ($callback) {
-            return $callback($arguments);
-        });
+        $filtered = collect($this->exceptions[$throwable] ?? [])
+            ->filter(fn ($arguments) => $callback($arguments));
 
         PHPUnit::assertTrue($filtered->count() > 0);
     }
 
-    public function handle(\Throwable $exception, $fileType = 'php', array $customData = [])
+    public function handle(Throwable $exception, string $fileType = 'php', array $customData = []): mixed
     {
-        $this->exceptions[get_class($exception)][] = $exception;
+        $this->exceptions[$exception::class][] = $exception;
+
+        return null;
     }
 }

--- a/src/Filters/DataFilter.php
+++ b/src/Filters/DataFilter.php
@@ -7,26 +7,22 @@ use Illuminate\Http\UploadedFile;
 
 class DataFilter
 {
-    protected array $blacklist;
+    /** @var array<int, string> */
+    protected readonly array $blacklist;
 
-    protected int $maxSize;
+    protected readonly int $maxSize;
 
     public function __construct(array $blacklist = [], int $maxSize = 10000)
     {
-        // Normalize blacklist to lowercase for case-insensitive matching
-        $this->blacklist = array_map(function ($item) {
-            return strtolower($item);
-        }, $blacklist);
+        // Lowercased once so matching is case-insensitive.
+        $this->blacklist = array_map(strtolower(...), $blacklist);
 
         $this->maxSize = $maxSize;
     }
 
-    /**
-     * Filter variables/arrays recursively
-     */
-    public function filterVariables($variables): array
+    public function filterVariables(mixed $variables): array
     {
-        if (!is_array($variables)) {
+        if (! is_array($variables)) {
             return [];
         }
 
@@ -44,7 +40,7 @@ class DataFilter
     }
 
     /**
-     * Filter payload data (for jobs)
+     * Filter payload data (for jobs).
      */
     public function filterPayload(array $payload): array
     {
@@ -54,37 +50,26 @@ class DataFilter
     }
 
     /**
-     * Filter parameters (combine variable filtering + parameter value filtering)
-     * This is the main method to use for request parameters
+     * The main entry point for request parameters: strips uploaded files
+     * first, then sensitive keys.
      */
     public function filterParameters(array $parameters): array
     {
-        // First filter out uploaded files
         $filtered = $this->filterParameterValues($parameters);
-        
-        // Then filter sensitive keys
+
         return $this->filterVariables($filtered);
     }
 
-    /**
-     * Filter parameter values (remove uploaded files)
-     */
     public function filterParameterValues(array $parameters): array
     {
-        return collect($parameters)->map(function ($value) {
-            if ($this->shouldParameterValueBeFiltered($value)) {
-                return '...';
-            }
-            return $value;
-        })->toArray();
+        return collect($parameters)
+            ->map(fn ($value) => $this->shouldParameterValueBeFiltered($value) ? '...' : $value)
+            ->toArray();
     }
 
-    /**
-     * Recursively filter data
-     */
-    protected function filterRecursive($data)
+    protected function filterRecursive(mixed $data): mixed
     {
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             return $data;
         }
 
@@ -93,17 +78,16 @@ class DataFilter
         foreach ($data as $key => $value) {
             if (is_string($key) && $this->shouldFilter($key)) {
                 $filtered[$key] = '[FILTERED]';
-            } else {
-                $filtered[$key] = $this->filterRecursive($value);
+
+                continue;
             }
+
+            $filtered[$key] = $this->filterRecursive($value);
         }
 
         return $filtered;
     }
 
-    /**
-     * Check if a key should be filtered based on blacklist
-     */
     protected function shouldFilter(string $key): bool
     {
         $lowerKey = strtolower($key);
@@ -118,17 +102,11 @@ class DataFilter
         return false;
     }
 
-    /**
-     * Check if parameter value should be filtered (e.g., uploaded files)
-     */
-    public function shouldParameterValueBeFiltered($value): bool
+    public function shouldParameterValueBeFiltered(mixed $value): bool
     {
         return $value instanceof UploadedFile;
     }
 
-    /**
-     * Truncate payload if it exceeds max size
-     */
     protected function truncateIfNeeded(array $payload): array
     {
         $json = json_encode($payload);
@@ -145,9 +123,7 @@ class DataFilter
         return $payload;
     }
 
-    /**
-     * Get the blacklist
-     */
+    /** @return array<int, string> */
     public function getBlacklist(): array
     {
         return $this->blacklist;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -2,35 +2,26 @@
 
 namespace LaraBug\Http;
 
+use Exception;
 use GuzzleHttp\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Exception\RequestException;
 
 class Client
 {
-    /** @var ClientInterface|null */
-    protected $client;
-
-    /** @var string */
-    protected $login;
-
-    /** @var string */
-    protected $project;
-
-    /**
-     * @param string $login
-     * @param string $project
-     * @param ClientInterface|null $client
-     */
-    public function __construct(string $login, string $project, ?ClientInterface $client = null)
-    {
-        $this->login = $login;
-        $this->project = $project;
-        $this->client = $client;
+    public function __construct(
+        protected readonly string $login,
+        protected readonly string $project,
+        protected ?ClientInterface $client = null,
+    ) {
     }
 
     /**
-     * @param array $exception
-     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\ResponseInterface|null
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * No native signature on purpose: test doubles override this method
+     * with a loose one.
+     *
+     * @param array<string, mixed> $exception
+     * @return ResponseInterface|null
      */
     public function report($exception)
     {
@@ -40,7 +31,7 @@ class Client
                     'Authorization' => 'Bearer '.$this->login,
                     'Content-Type' => 'application/json',
                     'Accept' => 'application/json',
-                    'User-Agent' => 'LaraBug-Package'
+                    'User-Agent' => 'LaraBug-Package',
                 ],
                 'json' => array_merge([
                     'project' => $this->project,
@@ -52,12 +43,12 @@ class Client
                     'strict' => true,  // Preserve POST method on redirects
                     'referer' => true,
                     'protocols' => ['http', 'https'],
-                    'track_redirects' => false
+                    'track_redirects' => false,
                 ],
             ]);
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             return $e->getResponse();
-        } catch (\Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -65,15 +56,14 @@ class Client
     /**
      * Report a batch of served HTTP requests.
      *
-     * The same endpoint and the same envelope as everything else, told apart by
-     * type. Each record carries the queries that request ran, inline, because
-     * they are one execution: a request whose queries arrived separately could
-     * have half of itself stored.
+     * The same endpoint and envelope as everything else, told apart by type.
+     * Each record carries the queries it ran inline, because they are one
+     * execution: a request whose queries arrived separately could have half
+     * of itself stored.
      *
      * @param  array<int, array<string, mixed>>  $records
-     * @return \Psr\Http\Message\ResponseInterface|null
      */
-    public function reportRequests(array $records)
+    public function reportRequests(array $records): ?ResponseInterface
     {
         try {
             return $this->getGuzzleHttpClient()->request('POST', config('larabug.server'), [
@@ -94,9 +84,9 @@ class Client
                 // the worker is still held, so our slowness is their capacity.
                 'timeout' => 5,
             ]);
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             return $e->getResponse();
-        } catch (\Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -104,7 +94,7 @@ class Client
     /**
      * @param  array<int, array<string, mixed>>  $records
      */
-    public function reportCommands(array $records)
+    public function reportCommands(array $records): ?ResponseInterface
     {
         try {
             return $this->getGuzzleHttpClient()->request('POST', config('larabug.server'), [
@@ -123,9 +113,9 @@ class Client
                 'verify' => config('larabug.verify_ssl'),
                 'timeout' => 5,
             ]);
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             return $e->getResponse();
-        } catch (\Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -133,7 +123,7 @@ class Client
     /**
      * @param  array<int, array<string, mixed>>  $records
      */
-    public function reportScheduledTasks(array $records)
+    public function reportScheduledTasks(array $records): ?ResponseInterface
     {
         try {
             return $this->getGuzzleHttpClient()->request('POST', config('larabug.server'), [
@@ -152,9 +142,9 @@ class Client
                 'verify' => config('larabug.verify_ssl'),
                 'timeout' => 5,
             ]);
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             return $e->getResponse();
-        } catch (\Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -165,11 +155,8 @@ class Client
      * Its own endpoint rather than a kind of report: this arrives on a schedule
      * whether or not anything happened, and the thing it proves is that the
      * sender is running at all.
-     *
-     * @param  array  $payload
-     * @return \Psr\Http\Message\ResponseInterface|null
      */
-    public function heartbeat(array $payload)
+    public function heartbeat(array $payload): ?ResponseInterface
     {
         try {
             return $this->getGuzzleHttpClient()->request('POST', $this->heartbeatUrl(), [
@@ -186,9 +173,9 @@ class Client
                 // schedule open behind it.
                 'timeout' => 5,
             ]);
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             return $e->getResponse();
-        } catch (\Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -196,8 +183,6 @@ class Client
     /**
      * Follows the reporting server unless told otherwise, so a self-hosted
      * install does not have to configure the same host twice.
-     *
-     * @return string
      */
     protected function heartbeatUrl(): string
     {
@@ -209,32 +194,21 @@ class Client
 
         $server = (string) config('larabug.server');
 
-        if (substr($server, -8) === '/api/log') {
+        if (str_ends_with($server, '/api/log')) {
             return substr($server, 0, -8).'/api/heartbeat';
         }
 
         return rtrim($server, '/').'/heartbeat';
     }
 
-    /**
-     * @return \GuzzleHttp\Client
-     */
-    public function getGuzzleHttpClient()
+    public function getGuzzleHttpClient(): ClientInterface
     {
-        if (! isset($this->client)) {
-            $this->client = new \GuzzleHttp\Client([
-                'timeout' => 15,
-            ]);
-        }
-
-        return $this->client;
+        return $this->client ??= new \GuzzleHttp\Client([
+            'timeout' => 15,
+        ]);
     }
 
-    /**
-     * @param ClientInterface $client
-     * @return $this
-     */
-    public function setGuzzleHttpClient(ClientInterface $client)
+    public function setGuzzleHttpClient(ClientInterface $client): static
     {
         $this->client = $client;
 

--- a/src/Http/Middleware/CaptureRequest.php
+++ b/src/Http/Middleware/CaptureRequest.php
@@ -3,12 +3,12 @@
 namespace LaraBug\Http\Middleware;
 
 use Closure;
+use Throwable;
 use Illuminate\Http\Request;
-use LaraBug\Requests\RequestBuffer;
-use LaraBug\Requests\RequestMonitor;
 use LaraBug\Requests\Sampler;
 use LaraBug\Requests\TraceContext;
-use Throwable;
+use LaraBug\Requests\RequestBuffer;
+use LaraBug\Requests\RequestMonitor;
 
 /**
  * Where a request's stage boundaries are marked, and where its record is

--- a/src/LaraBug.php
+++ b/src/LaraBug.php
@@ -5,39 +5,35 @@ namespace LaraBug;
 use Throwable;
 use LaraBug\Http\Client;
 use LaraBug\Filters\DataFilter;
+use LaraBug\Concerns\Larabugable;
 use LaraBug\Requests\TraceContext;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\App;
+use LaraBug\Requests\RequestMonitor;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
+use Psr\Http\Message\ResponseInterface;
 
 class LaraBug
 {
-    /** @var Client */
-    private $client;
+    private readonly Client $client;
 
-    /** @var DataFilter */
-    private $dataFilter;
+    private readonly DataFilter $dataFilter;
 
-    /** @var null|string */
-    private $lastExceptionId;
+    private ?string $lastExceptionId = null;
 
-    /** @var array */
-    private static $customContext = [];
+    /** @var array<string, mixed> */
+    private static array $customContext = [];
 
     /**
      * Re-entry guard. Set while handle() is executing so any exception
      * thrown *inside* the capture path (HTTP errors, serialization, etc.)
      * can't recursively trigger another capture and blow the stack.
-     *
-     * @var bool
      */
-    private static $capturing = false;
+    private static bool $capturing = false;
 
-    /**
-     * @param Client $client
-     */
     public function __construct(Client $client)
     {
         $this->client = $client;
@@ -45,32 +41,21 @@ class LaraBug
     }
 
     /**
-     * Set custom context data that will be sent with the next exception
-     * 
-     * @param array $context
-     * @return void
+     * Set custom context data that will be sent with the next exception.
+     *
+     * @param array<string, mixed> $context
      */
-    public static function context(array $context)
+    public static function context(array $context): void
     {
         self::$customContext = array_merge(self::$customContext, $context);
     }
 
-    /**
-     * Clear custom context data
-     * 
-     * @return void
-     */
-    public static function clearContext()
+    public static function clearContext(): void
     {
         self::$customContext = [];
     }
 
-    /**
-     * @param Throwable $exception
-     * @param string $fileType
-     * @return bool|mixed
-     */
-    public function handle(Throwable $exception, $fileType = 'php', array $customData = [])
+    public function handle(Throwable $exception, string $fileType = 'php', array $customData = []): mixed
     {
         // Drop any capture that re-enters while another capture is still in flight.
         // Without this, an error thrown inside logError() would be caught by
@@ -125,7 +110,7 @@ class LaraBug
 
                     $index = $currentLine - 1;
 
-                    if (!array_key_exists($index, $lines)) {
+                    if (! array_key_exists($index, $lines)) {
                         continue;
                     }
 
@@ -144,7 +129,7 @@ class LaraBug
 
             $rawResponse = $this->logError($data);
 
-            if (!$rawResponse) {
+            if (! $rawResponse) {
                 return false;
             }
 
@@ -180,10 +165,7 @@ class LaraBug
         return self::$capturing;
     }
 
-    /**
-     * @return bool
-     */
-    public function isSkipEnvironment()
+    public function isSkipEnvironment(): bool
     {
         if (count(config('larabug.environments', [])) == 0) {
             return true;
@@ -196,27 +178,19 @@ class LaraBug
         return true;
     }
 
-    /**
-     * @param string|null $id
-     */
-    private function setLastExceptionId(?string $id)
+    private function setLastExceptionId(?string $id): void
     {
         $this->lastExceptionId = $id;
     }
 
     /**
      * Get the last exception id given to us by the larabug API.
-     * @return string|null
      */
-    public function getLastExceptionId()
+    public function getLastExceptionId(): ?string
     {
         return $this->lastExceptionId;
     }
 
-    /**
-     * @param Throwable $exception
-     * @return array
-     */
     /**
      * Count this exception against the request that caused it, and stamp the
      * shared trace id onto the report.
@@ -232,13 +206,14 @@ class LaraBug
                 return;
             }
 
-            app(\LaraBug\Requests\RequestMonitor::class)->recordException();
-        } catch (Throwable $e) {
+            app(RequestMonitor::class)->recordException();
+        } catch (Throwable) {
             //
         }
     }
 
-    public function getExceptionData(Throwable $exception)
+    /** @return array<string, mixed> */
+    public function getExceptionData(Throwable $exception): array
     {
         $data = [];
 
@@ -250,7 +225,7 @@ class LaraBug
         $data['error'] = $exception->getTraceAsString();
         $data['line'] = $exception->getLine();
         $data['file'] = $exception->getFile();
-        $data['class'] = get_class($exception);
+        $data['class'] = $exception::class;
         $data['release'] = config('larabug.release', null);
         $data['storage'] = [
             'SERVER' => [
@@ -264,7 +239,7 @@ class LaraBug
             'COOKIE' => $this->filterVariables(Request::cookie()),
             'SESSION' => $this->filterVariables(Request::hasSession() ? Session::all() : []),
             'HEADERS' => $this->filterVariables(Request::header()),
-            'PARAMETERS' => $this->filterVariables($this->filterParameterValues(Request::all()))
+            'PARAMETERS' => $this->filterVariables($this->filterParameterValues(Request::all())),
         ];
 
         $data['storage'] = array_filter($data['storage']);
@@ -291,20 +266,16 @@ class LaraBug
 
         $data['frames'] = $this->getExceptionFrames($exception);
 
-        // Get project version
         $data['project_version'] = config('larabug.project_version', null);
 
-        // The trace this exception was thrown in. An exception thrown while
-        // serving a request carries that request's id (the middleware set it
-        // before routing), which is what lets the server join the failed
-        // request to the issue it caused. Outside a tracked request this is a
-        // fresh id that simply no request shares.
+        // An exception thrown while serving a tracked request carries that
+        // request's id (the middleware set it before routing), which is what
+        // lets the server join the failed request to the issue it caused.
+        // Outside a tracked request this is a fresh id no request shares.
         $data['trace_id'] = TraceContext::id();
 
-        // Add custom context data
-        if (!empty(self::$customContext)) {
+        if (! empty(self::$customContext)) {
             $data['custom_data'] = self::$customContext;
-            // Clear context after adding to exception
             self::$customContext = [];
         }
 
@@ -319,31 +290,17 @@ class LaraBug
         return $data;
     }
 
-    /**
-     * @param array $parameters
-     * @return array
-     */
-    public function filterParameterValues($parameters)
+    public function filterParameterValues(array $parameters): array
     {
         return $this->dataFilter->filterParameterValues($parameters);
     }
 
-    /**
-     * Determines whether the given parameter value should be filtered.
-     *
-     * @param mixed $value
-     * @return bool
-     */
-    public function shouldParameterValueBeFiltered($value)
+    public function shouldParameterValueBeFiltered(mixed $value): bool
     {
         return $this->dataFilter->shouldParameterValueBeFiltered($value);
     }
 
-    /**
-     * @param $variables
-     * @return array
-     */
-    public function filterVariables($variables)
+    public function filterVariables(mixed $variables): array
     {
         return $this->dataFilter->filterVariables($variables);
     }
@@ -351,18 +308,15 @@ class LaraBug
     /**
      * The stack as structured frames, each with a window of source around its
      * line, the way Sentry and Flare capture one. The throw site leads, since
-     * getTrace() does not include it, followed by the trace's own frames.
+     * getTrace() does not include it.
      *
      * Bounded twice: frame_lines_count lines of source either side of a
      * frame's line, and source for at most max_code_frames frames. Deeper
-     * frames keep their file, line and function so the trace stays whole;
-     * only the source windows stop. `error` and `executor` are untouched, so
-     * a server that does not know this field loses nothing.
+     * frames keep their file, line and function so the trace stays whole.
      *
-     * @param Throwable $exception
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
-    private function getExceptionFrames(Throwable $exception)
+    private function getExceptionFrames(Throwable $exception): array
     {
         $lineCount = (int) config('larabug.frame_lines_count', 5);
 
@@ -435,23 +389,14 @@ class LaraBug
         return $frames;
     }
 
-    /**
-     * Gets information from the line.
-     *
-     * @param $lines
-     * @param $line
-     * @param $i
-     *
-     * @return array|void
-     */
-    private function getLineInfo($lines, $line, $i)
+    private function getLineInfo(array $lines, int $line, int $i): ?array
     {
         $currentLine = $line + $i;
 
         $index = $currentLine - 1;
 
-        if (!array_key_exists($index, $lines)) {
-            return;
+        if (! array_key_exists($index, $lines)) {
+            return null;
         }
 
         return [
@@ -460,20 +405,12 @@ class LaraBug
         ];
     }
 
-    /**
-     * @param $exceptionClass
-     * @return bool
-     */
-    public function isSkipException($exceptionClass)
+    public function isSkipException(mixed $exceptionClass): bool
     {
         return in_array($exceptionClass, config('larabug.except'));
     }
 
-    /**
-     * @param array $data
-     * @return bool
-     */
-    public function isSleepingException(array $data)
+    public function isSleepingException(array $data): bool
     {
         if (config('larabug.sleep', 0) == 0) {
             return false;
@@ -482,23 +419,15 @@ class LaraBug
         return Cache::has($this->createExceptionString($data));
     }
 
-    /**
-     * @param array $data
-     * @return string
-     */
-    private function createExceptionString(array $data)
+    private function createExceptionString(array $data): string
     {
-        $string = $data['host'] . '_' . $data['method'] . '_' . $data['exception'] . '_' . $data['line'] . '_' . $data['file'] . '_' . $data['class'];
-        
-        // Hash the string to ensure it never exceeds cache key length limits (255 chars for database driver)
-        return 'larabug.' . md5($string);
+        $string = "{$data['host']}_{$data['method']}_{$data['exception']}_{$data['line']}_{$data['file']}_{$data['class']}";
+
+        // Hashed so the key never exceeds cache key length limits (255 chars for the database driver).
+        return 'larabug.'.md5($string);
     }
 
-    /**
-     * @param $exception
-     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\ResponseInterface|null
-     */
-    private function logError($exception)
+    private function logError(array $exception): ?ResponseInterface
     {
         return $this->client->report([
             'exception' => $exception,
@@ -506,32 +435,34 @@ class LaraBug
         ]);
     }
 
-    /**
-     * @return array|null
-     */
-    public function getUser()
+    public function getUser(): ?array
     {
-        if (function_exists('auth') && (app() instanceof \Illuminate\Foundation\Application && auth()->check())) {
-            /** @var \Illuminate\Contracts\Auth\Authenticatable $user */
-            $user = auth()->user();
+        if (! function_exists('auth')) {
+            return null;
+        }
 
-            if ($user instanceof \LaraBug\Concerns\Larabugable) {
-                return $user->toLarabug();
-            }
+        if (! (app() instanceof Application)) {
+            return null;
+        }
 
-            if ($user instanceof \Illuminate\Database\Eloquent\Model) {
-                return $user->toArray();
-            }
+        if (! auth()->check()) {
+            return null;
+        }
+
+        $user = auth()->user();
+
+        if ($user instanceof Larabugable) {
+            return $user->toLarabug();
+        }
+
+        if ($user instanceof Model) {
+            return $user->toArray();
         }
 
         return null;
     }
 
-    /**
-     * @param array $data
-     * @return bool
-     */
-    public function addExceptionToSleep(array $data)
+    public function addExceptionToSleep(array $data): bool
     {
         $exceptionString = $this->createExceptionString($data);
 

--- a/src/Logger/LaraBugHandler.php
+++ b/src/Logger/LaraBugHandler.php
@@ -9,32 +9,22 @@ use Monolog\Handler\AbstractProcessingHandler;
 
 class LaraBugHandler extends AbstractProcessingHandler
 {
-    /** @var LaraBug */
-    protected $laraBug;
-
-    /**
-     * @param LaraBug $laraBug
-     * @param int $level
-     * @param bool $bubble
-     */
-    public function __construct(LaraBug $laraBug, $level = Logger::ERROR, bool $bubble = true)
-    {
-        $this->laraBug = $laraBug;
-
+    public function __construct(
+        protected readonly LaraBug $laraBug,
+        $level = Logger::ERROR,
+        bool $bubble = true,
+    ) {
         parent::__construct($level, $bubble);
     }
 
-    /**
-     * @param array $record
-     */
     protected function write($record): void
     {
-        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof Throwable) {
-            $this->laraBug->handle(
-                $record['context']['exception']
-            );
+        $exception = $record['context']['exception'] ?? null;
 
+        if (! $exception instanceof Throwable) {
             return;
         }
+
+        $this->laraBug->handle($exception);
     }
 }

--- a/src/Logger/LaraBugLogHandler.php
+++ b/src/Logger/LaraBugLogHandler.php
@@ -2,46 +2,32 @@
 
 namespace LaraBug\Logger;
 
-use DateTimeInterface;
+use Throwable;
+use ArrayAccess;
+use Monolog\Logger;
 use JsonSerializable;
+use DateTimeInterface;
 use LaraBug\Requests\TraceContext;
 use Monolog\Handler\AbstractProcessingHandler;
-use Monolog\Logger;
-use Throwable;
 
 /**
  * Ships log lines to LaraBug.
  *
- * Separate from LaraBugHandler on purpose. That one exists to turn a logged
- * Throwable into an exception report and sits at ERROR; this one is interested
- * in the ordinary lines around an error, so it runs at a much lower level and
- * must stay cheap enough to sit in a request's hot path.
+ * Separate from LaraBugHandler on purpose: that one turns a logged Throwable
+ * into an exception report at ERROR level, while this one ships the ordinary
+ * lines around an error and must stay cheap enough for a request's hot path.
  */
 class LaraBugLogHandler extends AbstractProcessingHandler
 {
-    /** @var LogBuffer */
-    protected $buffer;
-
-    /** @var array */
-    protected $config;
-
-    /**
-     * @param LogBuffer $buffer
-     * @param array $config
-     * @param int $level
-     * @param bool $bubble
-     */
-    public function __construct(LogBuffer $buffer, array $config = [], $level = Logger::DEBUG, bool $bubble = true)
-    {
-        $this->buffer = $buffer;
-        $this->config = $config;
-
+    public function __construct(
+        protected readonly LogBuffer $buffer,
+        protected readonly array $config = [],
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+    ) {
         parent::__construct($level, $bubble);
     }
 
-    /**
-     * @param array $record
-     */
     protected function write($record): void
     {
         if (! $this->buffer->enabled()) {
@@ -59,17 +45,13 @@ class LaraBugLogHandler extends AbstractProcessingHandler
      * Monolog 3 hands over a LogRecord object rather than an array, but it
      * implements ArrayAccess over the same keys, so one accessor covers 1, 2
      * and 3 without branching on the version.
-     *
-     * @param array|\ArrayAccess $record
-     * @return array
      */
-    protected function toPayload($record): array
+    protected function toPayload(array|ArrayAccess $record): array
     {
         $context = $this->arrayValue($record, 'context');
 
-        // The exception object is what LaraBugHandler reports separately. Left
-        // in place it would be the single largest thing in the payload, and the
-        // interesting parts of it are already on the exception report.
+        // The exception object is what LaraBugHandler reports separately; left in
+        // place it would be the single largest thing in the payload.
         unset($context['exception']);
 
         return [
@@ -82,10 +64,8 @@ class LaraBugLogHandler extends AbstractProcessingHandler
             // not into context, so dropping it would lose most of what makes a
             // line useful.
             'extra' => $this->normalize($this->arrayValue($record, 'extra')),
-            // Falls back to the ambient trace rather than to nothing. An
-            // application that never sets one still gets its lines joined to
-            // the request or the job that wrote them, which is the entire
-            // reason the field exists.
+            // Falls back to the ambient trace so lines are joined to the request
+            // or job that wrote them even when the app never sets a trace id.
             'trace_id' => $this->traceId($record),
             'exception_id' => (string) $this->correlation($record, 'exception_id'),
             'environment' => (string) ($this->config['environment'] ?? ''),
@@ -94,11 +74,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
         ];
     }
 
-    /**
-     * @param array|\ArrayAccess $record
-     * @return string
-     */
-    protected function timestamp($record): string
+    protected function timestamp(array|ArrayAccess $record): string
     {
         $datetime = $this->value($record, 'datetime');
 
@@ -109,11 +85,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
         return date('Y-m-d\TH:i:s.000P');
     }
 
-    /**
-     * @param array|\ArrayAccess $record
-     * @return string
-     */
-    protected function level($record): string
+    protected function level(array|ArrayAccess $record): string
     {
         $name = $this->value($record, 'level_name');
 
@@ -127,19 +99,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
         return strtolower($name);
     }
 
-    /**
-     * Correlation ids travel in whichever bag the application happened to use,
-     * so both are checked rather than picking a side.
-     *
-     * @param array|\ArrayAccess $record
-     * @param string $key
-     * @return string
-     */
-    /**
-     * @param array|\ArrayAccess $record
-     * @return string
-     */
-    protected function traceId($record): string
+    protected function traceId(array|ArrayAccess $record): string
     {
         $supplied = $this->correlation($record, 'trace_id');
 
@@ -156,10 +116,10 @@ class LaraBugLogHandler extends AbstractProcessingHandler
     }
 
     /**
-     * @param array|\ArrayAccess $record
-     * @return string
+     * Correlation ids travel in whichever bag the application happened to use,
+     * so both are checked rather than picking a side.
      */
-    protected function correlation($record, string $key): string
+    protected function correlation(array|ArrayAccess $record, string $key): string
     {
         foreach (['context', 'extra'] as $bag) {
             $values = $this->arrayValue($record, $bag);
@@ -176,12 +136,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
      * Reduce a context bag to something that survives json_encode.
      *
      * Bounded on purpose: log context routinely holds whole models, and sending
-     * an object graph per line is how a logging integration turns into an
-     * outage.
-     *
-     * @param array $values
-     * @param int $depth
-     * @return array
+     * an object graph per line is how a logging integration turns into an outage.
      */
     protected function normalize(array $values, int $depth = 0): array
     {
@@ -193,6 +148,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
         foreach ($values as $key => $value) {
             if (count($normalized) >= $max) {
                 $normalized['_truncated'] = true;
+
                 break;
             }
 
@@ -202,12 +158,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
         return $normalized;
     }
 
-    /**
-     * @param mixed $value
-     * @param int $depth
-     * @return mixed
-     */
-    protected function normalizeValue($value, int $depth)
+    protected function normalizeValue(mixed $value, int $depth): mixed
     {
         if (is_scalar($value) || $value === null) {
             return is_string($value) ? $this->truncate($value) : $value;
@@ -227,9 +178,9 @@ class LaraBugLogHandler extends AbstractProcessingHandler
 
         if ($value instanceof Throwable) {
             return [
-                'class' => get_class($value),
+                'class' => $value::class,
                 'message' => $this->truncate($value->getMessage()),
-                'file' => $value->getFile().':'.$value->getLine(),
+                'file' => "{$value->getFile()}:{$value->getLine()}",
             ];
         }
 
@@ -243,7 +194,7 @@ class LaraBugLogHandler extends AbstractProcessingHandler
             try {
                 return $this->normalize((array) $value->toArray(), $depth + 1);
             } catch (Throwable $e) {
-                return get_class($value);
+                return $value::class;
             }
         }
 
@@ -251,13 +202,9 @@ class LaraBugLogHandler extends AbstractProcessingHandler
             return $this->truncate((string) $value);
         }
 
-        return is_object($value) ? get_class($value) : '[resource]';
+        return is_object($value) ? $value::class : '[resource]';
     }
 
-    /**
-     * @param string $value
-     * @return string
-     */
     protected function truncate(string $value): string
     {
         $limit = 2000;
@@ -265,31 +212,16 @@ class LaraBugLogHandler extends AbstractProcessingHandler
         return strlen($value) > $limit ? substr($value, 0, $limit).'…' : $value;
     }
 
-    /**
-     * @param array|\ArrayAccess $record
-     * @param string $key
-     * @param mixed $default
-     * @return mixed
-     */
-    protected function value($record, string $key, $default = null)
+    protected function value(array|ArrayAccess $record, string $key, mixed $default = null): mixed
     {
         if (is_array($record)) {
             return array_key_exists($key, $record) ? $record[$key] : $default;
         }
 
-        if ($record instanceof \ArrayAccess) {
-            return isset($record[$key]) ? $record[$key] : $default;
-        }
-
-        return $default;
+        return $record[$key] ?? $default;
     }
 
-    /**
-     * @param array|\ArrayAccess $record
-     * @param string $key
-     * @return array
-     */
-    protected function arrayValue($record, string $key): array
+    protected function arrayValue(array|ArrayAccess $record, string $key): array
     {
         $value = $this->value($record, $key, []);
 

--- a/src/Logger/LogBuffer.php
+++ b/src/Logger/LogBuffer.php
@@ -2,52 +2,36 @@
 
 namespace LaraBug\Logger;
 
-use LaraBug\Http\Client;
 use Throwable;
+use LaraBug\Http\Client;
 
 /**
- * Buffers log records and ships them in batches.
- *
- * Mirrors Queue\EventBuffer, which solves the same problem for jobs: one HTTP
- * request per log line would cost far more in network than the line is worth,
- * and at log volume it would be the dominant cost in the request.
+ * Buffers log records and ships them in batches, mirroring Queue\EventBuffer:
+ * one HTTP request per log line would cost far more in network than the line
+ * is worth.
  *
  * Nothing in here may throw. Monolog rethrows whatever a handler throws, which
- * would surface at the user's Log::info() call site and break their
- * application, so every path out of this class swallows.
+ * would surface at the user's Log call site, so every path out of this class
+ * swallows.
  */
 class LogBuffer
 {
-    /** @var Client */
-    protected $client;
-
-    /** @var array */
-    protected $config;
-
-    /** @var array */
-    protected $buffer = [];
+    protected array $buffer = [];
 
     /**
-     * Guards against logging while shipping logs.
-     *
-     * Monolog's own cycle detection is per Logger instance, so it does not help
-     * when our HTTP client, or anything it touches, logs to a different channel
-     * that reaches us again.
-     *
-     * @var bool
+     * Guards against logging while shipping logs. Monolog's own cycle detection
+     * is per Logger instance, so it does not help when our HTTP client logs to
+     * a different channel that reaches us again.
      */
-    protected $sending = false;
+    protected bool $sending = false;
 
-    public function __construct(Client $client, array $config)
-    {
-        $this->client = $client;
-        $this->config = $config;
+    public function __construct(
+        protected readonly Client $client,
+        protected array $config,
+    ) {
     }
 
-    /**
-     * @param array $record
-     */
-    public function add(array $record)
+    public function add(array $record): void
     {
         if ($this->sending) {
             return;
@@ -60,7 +44,7 @@ class LogBuffer
         }
     }
 
-    public function flush()
+    public function flush(): void
     {
         if (empty($this->buffer) || $this->sending) {
             return;
@@ -72,11 +56,7 @@ class LogBuffer
         $this->send($records);
     }
 
-    /**
-     * @param array $records
-     * @param int $attempt
-     */
-    protected function send(array $records, $attempt = 1)
+    protected function send(array $records, int $attempt = 1): void
     {
         $this->sending = true;
 
@@ -120,31 +100,23 @@ class LogBuffer
     }
 
     /**
-     * Stop collecting for the rest of this process.
-     *
-     * The server has told us it does not want these, so the handler should stop
-     * asking rather than repeat the round trip on every request.
+     * Stop collecting for the rest of this process: the server has said it does
+     * not want these, so stop repeating the round trip on every request.
      */
-    protected function disable()
+    protected function disable(): void
     {
         $this->buffer = [];
         $this->config['logs']['enabled'] = false;
         $this->sending = false;
     }
 
-    /**
-     * @return bool
-     */
-    public function enabled()
+    public function enabled(): bool
     {
         return ! isset($this->config['logs']['enabled'])
             || $this->config['logs']['enabled'];
     }
 
-    /**
-     * @return int
-     */
-    protected function batchSize()
+    protected function batchSize(): int
     {
         $size = isset($this->config['logs']['batch_size'])
             ? (int) $this->config['logs']['batch_size']
@@ -153,14 +125,7 @@ class LogBuffer
         return $size > 0 ? $size : 50;
     }
 
-    /**
-     * A hard ceiling on what one process may hold, so a long running worker or
-     * a command emitting thousands of lines cannot grow the buffer unbounded
-     * between flushes.
-     *
-     * @return int
-     */
-    public function bufferedCount()
+    public function bufferedCount(): int
     {
         return count($this->buffer);
     }

--- a/src/Queue/Concerns/Trackable.php
+++ b/src/Queue/Concerns/Trackable.php
@@ -4,40 +4,22 @@ namespace LaraBug\Queue\Concerns;
 
 trait Trackable
 {
-    /**
-     * Indicates if this job should be tracked by LaraBug.
-     *
-     * @var bool
-     */
-    public $trackInLaraBug = true;
+    public bool $trackInLaraBug = true;
 
-    /**
-     * Enable tracking for this job in LaraBug.
-     *
-     * @return $this
-     */
     public function track(): self
     {
         $this->trackInLaraBug = true;
+
         return $this;
     }
 
-    /**
-     * Disable tracking for this job in LaraBug.
-     *
-     * @return $this
-     */
     public function dontTrack(): self
     {
         $this->trackInLaraBug = false;
+
         return $this;
     }
 
-    /**
-     * Check if this job should be tracked by LaraBug.
-     *
-     * @return bool
-     */
     public function shouldTrackInLaraBug(): bool
     {
         return $this->trackInLaraBug ?? true;

--- a/src/Queue/DispatchMacros.php
+++ b/src/Queue/DispatchMacros.php
@@ -2,64 +2,48 @@
 
 namespace LaraBug\Queue;
 
-use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Bus\PendingChain;
+use Illuminate\Foundation\Bus\PendingDispatch;
 
 /**
- * Register ->track() macros on all Laravel dispatch classes
- * 
- * Supports:
- * - PendingDispatch (standard jobs)
- * - PendingClosureDispatch (closure jobs - inherits from PendingDispatch)
- * - PendingChain (job chains)
+ * Registers ->track() macros on PendingDispatch (which PendingClosureDispatch
+ * inherits from) and PendingChain.
  */
 class DispatchMacros
 {
-    /**
-     * Register the ->track() macro on all dispatch types
-     */
     public static function register(): void
     {
         self::registerOnPendingDispatch();
         self::registerOnPendingChain();
     }
 
-    /**
-     * Register ->track() on PendingDispatch
-     */
     protected static function registerOnPendingDispatch(): void
     {
-        if (method_exists(PendingDispatch::class, 'macro')) {
-            PendingDispatch::macro('track', function (bool $track = true) {
-                // Store tracking preference in the job's properties
-                if (property_exists($this->job, 'trackInLaraBug')) {
-                    $this->job->trackInLaraBug = $track;
-                } else {
-                    // Dynamically add the property
-                    $this->job->trackInLaraBug = $track;
-                }
-
-                return $this;
-            });
+        if (! method_exists(PendingDispatch::class, 'macro')) {
+            return;
         }
+
+        PendingDispatch::macro('track', function (bool $track = true) {
+            $this->job->trackInLaraBug = $track;
+
+            return $this;
+        });
     }
 
-    /**
-     * Register ->track() on PendingChain
-     */
     protected static function registerOnPendingChain(): void
     {
-        if (method_exists(PendingChain::class, 'macro')) {
-            PendingChain::macro('track', function (bool $track = true) {
-                // For chains, mark all jobs in the chain
-                foreach ($this->chain as $job) {
-                    if (is_object($job)) {
-                        $job->trackInLaraBug = $track;
-                    }
-                }
-
-                return $this;
-            });
+        if (! method_exists(PendingChain::class, 'macro')) {
+            return;
         }
+
+        PendingChain::macro('track', function (bool $track = true) {
+            foreach ($this->chain as $job) {
+                if (is_object($job)) {
+                    $job->trackInLaraBug = $track;
+                }
+            }
+
+            return $this;
+        });
     }
 }

--- a/src/Queue/DispatchMixin.php
+++ b/src/Queue/DispatchMixin.php
@@ -2,11 +2,11 @@
 
 namespace LaraBug\Queue;
 
+use Closure;
+
 /**
- * Mixin for all Laravel dispatch classes
- * 
- * This provides IDE autocomplete support for ->track() method
- * 
+ * Mixin for Laravel's dispatch classes, providing IDE autocomplete for ->track().
+ *
  * @mixin \Illuminate\Foundation\Bus\PendingDispatch
  * @mixin \Illuminate\Foundation\Bus\PendingChain
  * @mixin \Illuminate\Foundation\Bus\PendingClosureDispatch
@@ -14,19 +14,12 @@ namespace LaraBug\Queue;
 class DispatchMixin
 {
     /**
-     * Enable LaraBug tracking for this specific job or chain
-     *
-     * @param bool $track
-     * @return \Closure|DispatchMixin
+     * Enable LaraBug tracking for this specific job or chain.
      */
-    public function track()
+    public function track(): Closure
     {
         return function (bool $track = true) {
-            if (property_exists($this->job, 'trackInLaraBug')) {
-                $this->job->trackInLaraBug = $track;
-            } else {
-                $this->job->trackInLaraBug = $track;
-            }
+            $this->job->trackInLaraBug = $track;
 
             return $this;
         };

--- a/src/Queue/EventBuffer.php
+++ b/src/Queue/EventBuffer.php
@@ -2,33 +2,31 @@
 
 namespace LaraBug\Queue;
 
-use Throwable;
 use Countable;
+use Throwable;
 use LaraBug\Http\Client;
 
 /**
- * In-memory event buffer for batching queue job events
- * 
- * Inspired by Laravel Nightwatch's RecordsBuffer but adapted for HTTP transport.
- * Reduces API calls by batching multiple events into single requests.
+ * In-memory event buffer for batching queue job events, inspired by Laravel
+ * Nightwatch's RecordsBuffer but adapted for HTTP transport.
  */
 class EventBuffer implements Countable
 {
     protected array $buffer = [];
-    
-    protected Client $client;
-    
-    protected array $config;
-    
-    protected int $batchSize;
-    
+
+    protected readonly Client $client;
+
+    protected readonly array $config;
+
+    protected readonly int $batchSize;
+
     protected int $lastFlushTime;
-    
-    protected int $flushInterval;
-    
+
+    protected readonly int $flushInterval;
+
     protected bool $shutdownHandlerRegistered = false;
-    
-    protected LoadMonitor $loadMonitor;
+
+    protected readonly LoadMonitor $loadMonitor;
 
     public function __construct(Client $client, array $config)
     {
@@ -38,42 +36,36 @@ class EventBuffer implements Countable
         $this->flushInterval = $config['jobs']['flush_interval'] ?? 30;
         $this->lastFlushTime = time();
         $this->loadMonitor = new LoadMonitor();
-        
+
         $this->registerShutdownHandler();
     }
 
     /**
-     * Add an event to the buffer (or send immediately if batching disabled)
+     * Add an event to the buffer, or send immediately while load is low.
      */
     public function add(array $data): void
     {
-        // Record job and check if batching should be enabled
         $batchingEnabled = $this->loadMonitor->recordJob();
-        
-        if (!$batchingEnabled) {
-            // Low load - send immediately without buffering
+
+        if (! $batchingEnabled) {
             $this->sendImmediately($data);
+
             return;
         }
-        
-        // High load - buffer the event
+
         $this->buffer[] = $data;
-        
-        // Auto-flush when buffer is full
+
         if (count($this->buffer) >= $this->batchSize) {
             $this->flush();
+
             return;
         }
-        
-        // Auto-flush based on time interval
+
         if (time() - $this->lastFlushTime >= $this->flushInterval) {
             $this->flush();
         }
     }
 
-    /**
-     * Send a single event immediately without buffering
-     */
     protected function sendImmediately(array $data): void
     {
         try {
@@ -82,16 +74,13 @@ class EventBuffer implements Countable
                 'project' => $this->config['project_key'],
                 'job' => $data,
             ];
-            
+
             $this->client->report($payload);
         } catch (Throwable $e) {
-            // Fail silently to not break user's application
+            // Fail silently to not break the user's application.
         }
     }
 
-    /**
-     * Flush all buffered events to the API
-     */
     public function flush(): void
     {
         if (empty($this->buffer)) {
@@ -105,9 +94,6 @@ class EventBuffer implements Countable
         $this->sendBatch($events);
     }
 
-    /**
-     * Send batch of events with retry logic
-     */
     protected function sendBatch(array $events, int $attempt = 1): void
     {
         try {
@@ -117,37 +103,39 @@ class EventBuffer implements Countable
                 'jobs' => $events,
                 'count' => count($events),
             ];
-            
+
             $maxRetries = $this->config['jobs']['max_retries'] ?? 3;
-            
+
             $response = $this->client->report($payload);
-            
-            // Check if request was successful
+
             if ($response && method_exists($response, 'getStatusCode')) {
                 $statusCode = $response->getStatusCode();
-                
-                // Retry on 5xx errors
+
                 if ($statusCode >= 500 && $attempt < $maxRetries) {
-                    usleep(100000 * $attempt); // Exponential backoff: 100ms, 200ms, 300ms
+                    usleep(100000 * $attempt); // Backoff: 100ms, 200ms, 300ms
+
                     $this->sendBatch($events, $attempt + 1);
+
                     return;
                 }
             }
         } catch (Throwable $e) {
-            // Retry on network failures
+            // Retry on network failures.
             if ($attempt < ($this->config['jobs']['max_retries'] ?? 3)) {
-                usleep(100000 * $attempt); // Exponential backoff
+                usleep(100000 * $attempt); // Backoff: 100ms, 200ms, 300ms
+
                 $this->sendBatch($events, $attempt + 1);
+
                 return;
             }
-            
-            // After max retries, report the error (if enabled) but don't break user's app
+
+            // After max retries, report the error (if enabled) but never break the user's app.
             $this->reportError($e, count($events));
         }
     }
 
     /**
-     * Report buffer errors back to LaraBug (ironic, but useful for debugging)
+     * Report buffer errors back to LaraBug (ironic, but useful for debugging).
      */
     protected function reportError(Throwable $e, int $lostEvents): void
     {
@@ -156,19 +144,19 @@ class EventBuffer implements Countable
                 $this->client->report([
                     'type' => 'buffer_error',
                     'exception' => [
-                        'class' => get_class($e),
+                        'class' => $e::class,
                         'message' => $e->getMessage(),
                         'lost_events' => $lostEvents,
                     ],
                 ]);
             }
         } catch (Throwable $ignored) {
-            // Never let error reporting break the app
+            // Never let error reporting break the app.
         }
     }
 
     /**
-     * Register shutdown handler to flush buffer on script end
+     * Flush whatever is still buffered when the script ends.
      */
     protected function registerShutdownHandler(): void
     {
@@ -176,31 +164,23 @@ class EventBuffer implements Countable
             return;
         }
 
-        register_shutdown_function(function () {
-            $this->flush();
-        });
+        register_shutdown_function($this->flush(...));
 
         $this->shutdownHandlerRegistered = true;
     }
 
-    /**
-     * Get current buffer size
-     */
     public function count(): int
     {
         return count($this->buffer);
     }
 
-    /**
-     * Check if buffer is full
-     */
     public function isFull(): bool
     {
         return count($this->buffer) >= $this->batchSize;
     }
 
     /**
-     * Clear the buffer without flushing
+     * Clear the buffer without flushing.
      */
     public function clear(): void
     {
@@ -208,7 +188,7 @@ class EventBuffer implements Countable
     }
 
     /**
-     * Get all buffered events (for testing)
+     * Get all buffered events (for testing).
      */
     public function getBufferedEvents(): array
     {

--- a/src/Queue/Heartbeat.php
+++ b/src/Queue/Heartbeat.php
@@ -2,21 +2,15 @@
 
 namespace LaraBug\Queue;
 
+use Throwable;
 use Illuminate\Support\Facades\Queue;
 
 /**
  * A periodic "the workers are alive" report.
  *
- * Everything else this package sends is a report about something that happened:
- * an exception, a job that ran. None of that can distinguish a queue with no
- * work from a queue with no workers, because both send nothing at all. This is
- * the one message that says a worker exists, which is why it is sent on a
- * schedule rather than in response to anything.
- *
- * Where Horizon is installed it is asked directly, since it already knows its
- * supervisors, their process counts and how long each queue has been waiting.
- * Without it the queue driver is asked how much is waiting, which is less but
- * is still measured rather than guessed.
+ * Every other message this package sends reports something that happened, and
+ * none of that can distinguish a queue with no work from a queue with no
+ * workers — both send nothing — so this one is sent on a schedule instead.
  */
 class Heartbeat
 {
@@ -36,9 +30,9 @@ class Heartbeat
     /**
      * What Horizon says about itself, or that it is not here.
      *
-     * Every repository call is guarded: Horizon can be installed and its Redis
-     * connection be down, and a heartbeat that throws is a heartbeat that never
-     * arrives, which the panel would read as the workers being gone.
+     * Every repository call is guarded: Horizon can be installed with its Redis
+     * connection down, and a heartbeat that throws never arrives, which the
+     * panel would read as the workers being gone.
      *
      * @return array<string, mixed>
      */
@@ -61,11 +55,10 @@ class Heartbeat
 
             $report['masters'] = count($masters);
 
-            // Horizon reports per master. One paused master is the whole thing
-            // paused as far as a queue is concerned, so the least healthy status
-            // wins rather than the first one read.
+            // One paused master is the whole thing paused as far as a queue is
+            // concerned, so the least healthy status wins.
             foreach ($masters as $master) {
-                $status = isset($master->status) ? $master->status : null;
+                $status = $master->status ?? null;
 
                 if ($report['status'] === null || $status === 'paused') {
                     $report['status'] = $status;
@@ -75,7 +68,7 @@ class Heartbeat
             if ($report['masters'] === 0) {
                 $report['status'] = 'inactive';
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $report['status'] = 'unknown';
         }
 
@@ -91,19 +84,19 @@ class Heartbeat
 
                 $options = isset($supervisor->options) ? (array) $supervisor->options : [];
 
-                // The two figures Horizon's own overview shows as "default" when
-                // the supervisor has not been given them.
+                // The figures Horizon's own overview shows as "default" when the
+                // supervisor has not been given them.
                 $report['supervisor_options'][] = [
-                    'name' => isset($supervisor->name) ? $supervisor->name : null,
-                    'max_processes' => isset($options['maxProcesses']) ? $options['maxProcesses'] : null,
-                    'max_runtime' => isset($options['maxTime']) ? $options['maxTime'] : null,
-                    'max_throughput' => isset($options['maxJobs']) ? $options['maxJobs'] : null,
-                    'balance' => isset($options['balance']) ? $options['balance'] : null,
+                    'name' => $supervisor->name ?? null,
+                    'max_processes' => $options['maxProcesses'] ?? null,
+                    'max_runtime' => $options['maxTime'] ?? null,
+                    'max_throughput' => $options['maxJobs'] ?? null,
+                    'balance' => $options['balance'] ?? null,
                 ];
             }
-        } catch (\Throwable $e) {
-            // Leave the counts at zero: the master status above is the part that
-            // says whether anything is running.
+        } catch (Throwable $e) {
+            // Leave the counts at zero: the master status above already says
+            // whether anything is running.
         }
 
         return $report;
@@ -112,9 +105,8 @@ class Heartbeat
     /**
      * How much is waiting on each queue, and how long it has been waiting.
      *
-     * Horizon's workload already answers both per queue, including the wait it
-     * measures itself. Without Horizon only the depth is available, and the
-     * panel is left to work out the age from the jobs it has been sent.
+     * Horizon's workload answers both per queue; without it only the depth is
+     * available and the panel works out the age from the jobs it has been sent.
      *
      * @return array<int, array<string, mixed>>
      */
@@ -133,10 +125,9 @@ class Heartbeat
 
             try {
                 $size = Queue::connection($entry['connection'])->size($entry['queue']);
-            } catch (\Throwable $e) {
-                // A driver that cannot be counted, such as sync, or a broker
-                // that is unreachable. Reporting null says "not measured",
-                // which is not the same as reporting nothing waiting.
+            } catch (Throwable $e) {
+                // A driver that cannot be counted (sync) or an unreachable broker.
+                // Null says "not measured", which is not the same as nothing waiting.
             }
 
             $queues[] = [
@@ -162,7 +153,7 @@ class Heartbeat
 
         try {
             $workload = app('\Laravel\Horizon\Contracts\WorkloadRepository')->get();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return null;
         }
 
@@ -172,12 +163,10 @@ class Heartbeat
             $entry = (array) $entry;
 
             $queues[] = [
-                // Horizon names a queue by the connection's queues joined with
-                // commas when a supervisor watches several; it is passed through
-                // as reported rather than split, since that string is what its
-                // own dashboard shows.
-                'connection' => isset($entry['connection']) ? $entry['connection'] : null,
-                'queue' => isset($entry['name']) ? $entry['name'] : null,
+                // Horizon joins a supervisor's queues with commas; passed through
+                // as reported, since that string is what its own dashboard shows.
+                'connection' => $entry['connection'] ?? null,
+                'queue' => $entry['name'] ?? null,
                 'size' => isset($entry['length']) ? (int) $entry['length'] : null,
                 // Seconds in Horizon, milliseconds everywhere in this payload.
                 'wait' => isset($entry['wait']) ? (int) round($entry['wait'] * 1000) : null,
@@ -189,10 +178,8 @@ class Heartbeat
     }
 
     /**
-     * The queues to measure when there is no Horizon to ask.
-     *
-     * Configured explicitly, or the default connection's own queue, which is
-     * the one an app that has never thought about this is using.
+     * The queues to measure when there is no Horizon to ask: configured
+     * explicitly, or the default connection's own queue.
      *
      * @return array<int, array<string, string>>
      */
@@ -211,8 +198,8 @@ class Heartbeat
                 }
 
                 $queues[] = [
-                    'connection' => isset($entry['connection']) ? $entry['connection'] : config('queue.default'),
-                    'queue' => isset($entry['queue']) ? $entry['queue'] : 'default',
+                    'connection' => $entry['connection'] ?? config('queue.default'),
+                    'queue' => $entry['queue'] ?? 'default',
                 ];
             }
 
@@ -223,7 +210,7 @@ class Heartbeat
 
         return [[
             'connection' => $connection,
-            'queue' => config('queue.connections.'.$connection.'.queue', 'default'),
+            'queue' => config("queue.connections.{$connection}.queue", 'default'),
         ]];
     }
 }

--- a/src/Queue/JobDataCollector.php
+++ b/src/Queue/JobDataCollector.php
@@ -2,20 +2,25 @@
 
 namespace LaraBug\Queue;
 
+use Exception;
+use Carbon\Carbon;
 use LaraBug\Filters\DataFilter;
 use Illuminate\Contracts\Queue\Job;
 
 class JobDataCollector
 {
-    protected array $config;
+    protected readonly array $config;
 
-    protected DataFilter $filterer;
+    protected readonly DataFilter $filterer;
 
     /**
-     * Cache of timestamps by job_id
-     * Persists for the lifetime of the worker process
+     * Timestamps by job id, cached for the lifetime of the worker process.
+     *
+     * @var array<string, string>
      */
     protected static array $reservedAtCache = [];
+
+    /** @var array<string, string> */
     protected static array $availableAtCache = [];
 
     public function __construct(array $config)
@@ -30,8 +35,7 @@ class JobDataCollector
     public function collect(Job $job, string $connectionName, string $status, array $extra = []): array
     {
         $payload = json_decode($job->getRawBody(), true) ?? [];
-        
-        // Use UUID from payload if available, otherwise fall back to job ID
+
         $jobId = $payload['uuid'] ?? $job->getJobId();
 
         $data = [
@@ -49,43 +53,38 @@ class JobDataCollector
             'created_at' => now()->toIso8601String(),
         ];
 
-        // Add timestamps based on status
-        // Set timestamps on first event (processing)
-        if ($status === 'processing' && !isset(static::$reservedAtCache[$jobId])) {
+        // available_at (when the job was pushed) and reserved_at (when a worker
+        // picked it up) are set on the first processing event and cached, so
+        // completed/failed events report the same values.
+        if ($status === 'processing' && ! isset(static::$reservedAtCache[$jobId])) {
             $now = now();
-            
-            // available_at: When job was pushed to queue (use pushedAt from payload if available)
-            $availableAt = isset($payload['pushedAt']) 
+
+            $availableAt = isset($payload['pushedAt'])
                 ? $this->convertTimestamp($payload['pushedAt'])
                 : $now->toIso8601String();
-            
-            // reserved_at: When worker picked up the job (now)
+
             $reservedAt = $now->toIso8601String();
-            
-            // Cache both timestamps
+
             static::$availableAtCache[$jobId] = $availableAt;
             static::$reservedAtCache[$jobId] = $reservedAt;
-            
+
             $data['available_at'] = $availableAt;
             $data['reserved_at'] = $reservedAt;
         } elseif (isset(static::$reservedAtCache[$jobId])) {
-            // Use cached timestamps for completed/failed states
             $data['available_at'] = static::$availableAtCache[$jobId] ?? null;
             $data['reserved_at'] = static::$reservedAtCache[$jobId];
         }
 
-        // completed_at: When job finished successfully
         if ($status === 'completed') {
             $data['completed_at'] = now()->toIso8601String();
-            // Clean up cache
+
             unset(static::$reservedAtCache[$jobId]);
             unset(static::$availableAtCache[$jobId]);
         }
 
-        // failed_at: When job failed
         if ($status === 'failed') {
             $data['failed_at'] = now()->toIso8601String();
-            // Clean up cache
+
             unset(static::$reservedAtCache[$jobId]);
             unset(static::$availableAtCache[$jobId]);
         }
@@ -93,24 +92,19 @@ class JobDataCollector
         return array_merge($data, $extra);
     }
 
-    /**
-     * Convert timestamp to ISO8601 string format
-     */
-    protected function convertTimestamp($timestamp): ?string
+    protected function convertTimestamp(mixed $timestamp): ?string
     {
         if ($timestamp === null) {
             return null;
         }
 
-        // If it's already a timestamp integer
         if (is_numeric($timestamp)) {
-            return \Carbon\Carbon::createFromTimestamp($timestamp)->toIso8601String();
+            return Carbon::createFromTimestamp($timestamp)->toIso8601String();
         }
 
-        // If it's a date string, try to parse it
         try {
-            return \Carbon\Carbon::parse($timestamp)->toIso8601String();
-        } catch (\Exception $e) {
+            return Carbon::parse($timestamp)->toIso8601String();
+        } catch (Exception $e) {
             return null;
         }
     }

--- a/src/Queue/JobEventSubscriber.php
+++ b/src/Queue/JobEventSubscriber.php
@@ -2,21 +2,23 @@
 
 namespace LaraBug\Queue;
 
-use Illuminate\Queue\Events\{JobProcessing, JobProcessed, JobFailed};
 use LaraBug\Requests\TraceContext;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class JobEventSubscriber
 {
-    protected JobMonitor $monitor;
-
+    /** @var array<string, array{start: float, memory_start: int}> */
     protected array $timings = [];
 
-    public function __construct(JobMonitor $monitor)
-    {
-        $this->monitor = $monitor;
+    public function __construct(
+        protected readonly JobMonitor $monitor,
+    ) {
     }
 
-    public function subscribe($events): void
+    public function subscribe(Dispatcher $events): void
     {
         $events->listen(JobProcessing::class, [$this, 'handleJobProcessing']);
         $events->listen(JobProcessed::class, [$this, 'handleJobProcessed']);
@@ -25,9 +27,8 @@ class JobEventSubscriber
 
     public function handleJobProcessing(JobProcessing $event): void
     {
-        // Each job is its own unit of work, so each gets its own trace. A
-        // worker process is long lived and would otherwise stamp every job it
-        // ever ran with the id of the first one.
+        // Each job is its own unit of work, so each gets its own trace: a long
+        // lived worker would otherwise stamp every job with the first job's id.
         TraceContext::reset();
 
         $jobId = $event->job->getJobId() ?? spl_object_hash($event->job);

--- a/src/Queue/JobMonitor.php
+++ b/src/Queue/JobMonitor.php
@@ -8,32 +8,29 @@ use Illuminate\Contracts\Queue\Job;
 
 class JobMonitor
 {
-    protected Client $client;
+    protected readonly Client $client;
 
-    protected array $config;
+    protected readonly array $config;
 
-    protected JobDataCollector $collector;
-    
-    protected ?EventBuffer $buffer = null;
+    protected readonly JobDataCollector $collector;
+
+    protected readonly ?EventBuffer $buffer;
 
     public function __construct(Client $client, array $config)
     {
         $this->client = $client;
         $this->config = $config;
         $this->collector = new JobDataCollector($config);
-        
-        // Initialize buffer for dynamic batching
         $this->buffer = new EventBuffer($client, $config);
     }
 
     public function trackJobStarted(Job $job, string $connectionName): void
     {
-        if (!$this->shouldTrack($job)) {
+        if (! $this->shouldTrack($job)) {
             return;
         }
-        
-        // Check if we should track processing events
-        if (!($this->config['jobs']['track_processing'] ?? false)) {
+
+        if (! ($this->config['jobs']['track_processing'] ?? false)) {
             return;
         }
 
@@ -44,17 +41,15 @@ class JobMonitor
 
     public function trackJobCompleted(Job $job, string $connectionName, ?float $durationMs, ?int $memoryUsed): void
     {
-        if (!$this->shouldTrack($job)) {
+        if (! $this->shouldTrack($job)) {
             return;
         }
-        
-        // Check if we should track completed events
-        if (!($this->config['jobs']['track_completed'] ?? true)) {
+
+        if (! ($this->config['jobs']['track_completed'] ?? true)) {
             return;
         }
-        
-        // Apply sampling rate
-        if (!$this->shouldSample()) {
+
+        if (! $this->shouldSample()) {
             return;
         }
 
@@ -68,11 +63,14 @@ class JobMonitor
 
     public function trackJobFailed(Job $job, string $connectionName, Throwable $exception, ?float $durationMs): void
     {
-        if (!$this->shouldTrack($job)) {
+        if (! $this->shouldTrack($job)) {
             return;
         }
-        
-        // Build storage data similar to regular exceptions
+
+        if (! ($this->config['jobs']['track_failed'] ?? true)) {
+            return;
+        }
+
         $storage = [
             'SERVER' => [
                 'USER' => $_SERVER['USER'] ?? null,
@@ -83,22 +81,17 @@ class JobMonitor
             ],
             'HEADERS' => getallheaders() ?: [],
         ];
-        
-        // ALWAYS track failures (unless explicitly disabled)
-        if (!($this->config['jobs']['track_failed'] ?? true)) {
-            return;
-        }
-        
+
         $data = $this->collector->collect($job, $connectionName, 'failed', [
             'duration_ms' => $durationMs,
             'exception' => [
-                'class' => get_class($exception),
+                'class' => $exception::class,
                 'message' => $exception->getMessage(),
                 'code' => $exception->getCode(),
                 'file' => $exception->getFile(),
                 'line' => $exception->getLine(),
-                'error' => $exception->getTraceAsString(), // Stack trace goes in error field
-                'storage' => array_filter($storage), // Server/headers data goes in storage field
+                'error' => $exception->getTraceAsString(), // Stack trace goes in the error field
+                'storage' => array_filter($storage), // Server/headers data goes in the storage field
                 'environment' => config('app.env', 'production'),
             ],
         ]);
@@ -106,29 +99,23 @@ class JobMonitor
         $this->send($data);
     }
 
-    /**
-     * Check if job should be tracked based on filters and configuration
-     */
     protected function shouldTrack(Job $job): bool
     {
-        // Check if tracking is globally disabled
-        if (!($this->config['jobs']['track_jobs'] ?? true)) {
+        if (! ($this->config['jobs']['track_jobs'] ?? true)) {
             return false;
         }
 
         // Don't track queue events while a regular exception capture is in flight —
-        // prevents the queue tracking path from re-entering the send pipeline
-        // while it is already being used by LaraBug::handle().
+        // prevents re-entering the send pipeline while LaraBug::handle() is using it.
         if (\LaraBug\LaraBug::isCapturing()) {
             return false;
         }
 
         $jobClass = $job->resolveName();
 
-        // Never track SDK-internal jobs. This is a hard-coded safety rail on top
-        // of the user-configurable ignore list below: when the LaraBug package is
-        // installed inside the LaraBug SaaS itself (dogfooding), we never want the
-        // ingest queue jobs shipping themselves back to the server.
+        // Hard-coded safety rail on top of the user-configurable ignore list: when
+        // the SDK is dogfooded inside the LaraBug SaaS itself, the ingest queue jobs
+        // must never ship themselves back to the server.
         if (is_string($jobClass) && (
             str_starts_with($jobClass, 'LaraBug\\')
             || str_starts_with($jobClass, 'Larabug\\')
@@ -136,19 +123,17 @@ class JobMonitor
             return false;
         }
 
-        // Check ignore list
         foreach ($this->config['jobs']['ignore_jobs'] ?? [] as $ignoredJob) {
             if ($jobClass === $ignoredJob || is_subclass_of($jobClass, $ignoredJob)) {
                 return false;
             }
         }
 
-        // Check queue filters
         $jobQueue = $job->getQueue();
         $onlyQueues = $this->config['jobs']['only_queues'] ?? [];
         $ignoreQueues = $this->config['jobs']['ignore_queues'] ?? [];
 
-        if (!empty($onlyQueues) && !in_array($jobQueue, $onlyQueues)) {
+        if (! empty($onlyQueues) && ! in_array($jobQueue, $onlyQueues)) {
             return false;
         }
 
@@ -162,51 +147,41 @@ class JobMonitor
     protected function send(array $data): void
     {
         try {
-            // Use buffer for dynamic batching
             if ($this->buffer) {
                 $this->buffer->add($data);
+
                 return;
             }
-            
-            // Fall back to direct sending if buffer not initialized
+
+            // Fall back to direct sending if the buffer was never initialized.
             $payload = [
                 'type' => 'queue_job',
                 'project' => $this->config['project_key'],
                 'job' => $data,
             ];
-            
+
             $this->client->report($payload);
         } catch (Throwable $e) {
-            // Silent fail - never break user's jobs
-            // But report the error if configured
+            // Silent fail — never break the user's jobs.
             $this->reportError($e);
         }
     }
-    
-    /**
-     * Apply sampling rate for successful job completions
-     */
+
     protected function shouldSample(): bool
     {
         $sampleRate = $this->config['jobs']['sample_rate'] ?? 1.0;
-        
-        // Always sample at 100%
+
         if ($sampleRate >= 1.0) {
             return true;
         }
-        
-        // Never sample
+
         if ($sampleRate <= 0.0) {
             return false;
         }
-        
-        // Random sampling
+
         return (mt_rand() / mt_getrandmax()) <= $sampleRate;
     }
-    
-    /**
-     * Report SDK errors (for debugging)
-     */
+
     protected function reportError(Throwable $e): void
     {
         try {
@@ -214,7 +189,7 @@ class JobMonitor
                 $this->client->report([
                     'type' => 'sdk_error',
                     'exception' => [
-                        'class' => get_class($e),
+                        'class' => $e::class,
                         'message' => $e->getMessage(),
                         'file' => $e->getFile(),
                         'line' => $e->getLine(),
@@ -222,17 +197,15 @@ class JobMonitor
                 ]);
             }
         } catch (Throwable $ignored) {
-            // Never let error reporting break the app
+            // Never let error reporting break the app.
         }
     }
-    
+
     /**
-     * Manually flush the buffer (useful for testing or long-running processes)
+     * Manually flush the buffer (useful for testing or long-running processes).
      */
     public function flush(): void
     {
-        if ($this->buffer) {
-            $this->buffer->flush();
-        }
+        $this->buffer?->flush();
     }
 }

--- a/src/Queue/LoadMonitor.php
+++ b/src/Queue/LoadMonitor.php
@@ -5,10 +5,15 @@ namespace LaraBug\Queue;
 class LoadMonitor
 {
     protected array $recentJobs = [];
-    protected int $highLoadThreshold;
-    protected int $lowLoadThreshold;
-    protected int $cooldownMinutes;
+
+    protected readonly int $highLoadThreshold;
+
+    protected readonly int $lowLoadThreshold;
+
+    protected readonly int $cooldownMinutes;
+
     protected ?int $batchingEnabledAt = null;
+
     protected bool $isEnabled = false;
 
     public function __construct()
@@ -19,52 +24,47 @@ class LoadMonitor
     }
 
     /**
-     * Record a job dispatch and check if batching should be enabled
+     * Record a job dispatch and report whether batching should be enabled.
      */
     public function recordJob(): bool
     {
         $now = time();
-        
-        // Add current job
+
         $this->recentJobs[] = $now;
-        
-        // Clean old jobs (older than 60 seconds)
-        $this->recentJobs = array_filter($this->recentJobs, function ($timestamp) use ($now) {
-            return $timestamp > ($now - 60);
-        });
-        
-        // Calculate current rate (jobs per minute)
+
+        $this->recentJobs = array_filter(
+            $this->recentJobs,
+            fn ($timestamp) => $timestamp > ($now - 60)
+        );
+
         $currentRate = count($this->recentJobs);
-        
-        // Check if we should enable batching
-        if (!$this->isEnabled && $currentRate >= $this->highLoadThreshold) {
+
+        if (! $this->isEnabled && $currentRate >= $this->highLoadThreshold) {
             $this->isEnabled = true;
             $this->batchingEnabledAt = $now;
         }
-        
-        // Check if we should disable batching (cooldown period passed)
+
+        // Disable only after the cooldown has passed, so batching does not flap
+        // around the threshold.
         if ($this->isEnabled && $currentRate < $this->lowLoadThreshold) {
             $enabledDuration = $now - $this->batchingEnabledAt;
-            
+
             if ($enabledDuration >= ($this->cooldownMinutes * 60)) {
                 $this->isEnabled = false;
                 $this->batchingEnabledAt = null;
             }
         }
-        
+
         return $this->isEnabled;
     }
 
-    /**
-     * Check if batching is currently enabled
-     */
     public function isBatchingEnabled(): bool
     {
         return $this->isEnabled;
     }
 
     /**
-     * Get current job rate (jobs per minute)
+     * Current job rate in jobs per minute.
      */
     public function getCurrentRate(): int
     {
@@ -72,7 +72,7 @@ class LoadMonitor
     }
 
     /**
-     * Get stats for monitoring
+     * @return array<string, mixed>
      */
     public function getStats(): array
     {

--- a/src/Requests/QueryNormaliser.php
+++ b/src/Requests/QueryNormaliser.php
@@ -7,8 +7,7 @@ namespace LaraBug\Requests;
  *
  * Two things blow up query cardinality in practice, and both are cheap to
  * collapse: an IN list whose length follows the data, and a multi-row INSERT
- * whose tuple count follows the batch. Left alone, one logical query becomes
- * thousands of distinct strings and the grouped view is useless.
+ * whose tuple count follows the batch.
  *
  * Normalising here rather than on ingest means the server never parses SQL at
  * request volume, and the hash the grouping relies on cannot drift between the
@@ -28,10 +27,9 @@ class QueryNormaliser
     }
 
     /**
-     * md5, not xxh128: this package supports PHP 7.4 and xxh128 arrived in 8.1,
-     * so the faster algorithm would have thrown on half the versions we claim
-     * to run on. It is a grouping key, not a signature — collisions cost a
-     * merged row, not a vulnerability.
+     * md5 stays deliberately: it is a grouping key, not a signature —
+     * collisions cost a merged row — and changing the algorithm would split
+     * every existing group.
      */
     public static function hash(string $connection, string $normalisedSql): string
     {

--- a/src/Requests/RequestBuffer.php
+++ b/src/Requests/RequestBuffer.php
@@ -3,16 +3,15 @@
 namespace LaraBug\Requests;
 
 use Countable;
-use LaraBug\Http\Client;
 use Throwable;
+use LaraBug\Http\Client;
 
 /**
  * Batches finished request records.
  *
  * A duplicate of EventBuffer rather than a generalisation of it, deliberately:
  * that buffer is in production carrying queue jobs, and the way to find out
- * whether one abstraction serves both is to run the second one first. They can
- * be merged once this is live.
+ * whether one abstraction serves both is to run the second one first.
  *
  * The flush happens on shutdown as well as on size, because a web process
  * serves one request and then exits: without it, every batch below the
@@ -21,27 +20,21 @@ use Throwable;
 class RequestBuffer implements Countable
 {
     /** @var array<int, array<string, mixed>> */
-    protected $buffer = [];
+    protected array $buffer = [];
 
-    /** @var Client */
-    protected $client;
+    protected readonly int $batchSize;
 
-    /** @var array<string, mixed> */
-    protected $config;
+    protected readonly int $maxRetries;
 
-    /** @var int */
-    protected $batchSize;
+    protected bool $shutdownRegistered = false;
 
-    /** @var int */
-    protected $maxRetries;
-
-    /** @var bool */
-    protected $shutdownRegistered = false;
-
-    public function __construct(Client $client, array $config)
-    {
-        $this->client = $client;
-        $this->config = $config;
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function __construct(
+        protected readonly Client $client,
+        protected readonly array $config,
+    ) {
         $this->batchSize = (int) ($config['requests']['batch_size'] ?? 20);
         $this->maxRetries = (int) ($config['requests']['max_retries'] ?? 2);
 
@@ -79,12 +72,11 @@ class RequestBuffer implements Countable
     {
         try {
             $this->client->reportRequests($records);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             if ($attempt <= $this->maxRetries) {
-                // Linear, not exponential. This runs on shutdown, after the
-                // response has been sent but while the worker is still held, so
-                // a doubling backoff spends the customer's capacity on our
-                // outage.
+                // Linear, not exponential: this runs on shutdown while the
+                // worker is still held, and a doubling backoff spends the
+                // customer's capacity on our outage.
                 usleep(100000 * $attempt);
 
                 $this->send($records, $attempt + 1);
@@ -105,9 +97,7 @@ class RequestBuffer implements Countable
 
         $this->shutdownRegistered = true;
 
-        register_shutdown_function(function () {
-            $this->flush();
-        });
+        register_shutdown_function($this->flush(...));
     }
 
     public function count(): int

--- a/src/Requests/RequestListeners.php
+++ b/src/Requests/RequestListeners.php
@@ -2,8 +2,24 @@
 
 namespace LaraBug\Requests;
 
-use Illuminate\Contracts\Events\Dispatcher;
 use Throwable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Queue\Events\JobQueued;
+use Illuminate\Cache\Events\KeyWritten;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Http\Client\Events\ConnectionFailed;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Notifications\Events\NotificationFailed;
 
 /**
  * The events that fill in a request record.
@@ -14,61 +30,44 @@ use Throwable;
  */
 class RequestListeners
 {
-    /** @var RequestMonitor */
-    protected $monitor;
-
-    /** @var Sampler */
-    protected $sampler;
-
     /** @var array<int, float> Send-start marks, in seconds, keyed by message. */
-    protected $mailStartedAt = [];
+    protected array $mailStartedAt = [];
 
-    public function __construct(RequestMonitor $monitor, Sampler $sampler)
-    {
-        $this->monitor = $monitor;
-        $this->sampler = $sampler;
+    public function __construct(
+        protected readonly RequestMonitor $monitor,
+        protected readonly Sampler $sampler,
+    ) {
     }
 
-    /**
-     * Registered one at a time rather than by returning a map, which the
-     * dispatcher only understands from Laravel 8. This package supports 6, and
-     * a subscriber that quietly listens to nothing is worse than one that fails
-     * loudly.
-     *
-     * Events that do not exist on older versions, such as JobQueued, are named
-     * as strings and simply never fire.
-     */
     public function subscribe(Dispatcher $events): void
     {
-        $events->listen('Illuminate\Routing\Events\RouteMatched', [$this, 'onRouteMatched']);
-        $events->listen('Illuminate\Database\Events\QueryExecuted', [$this, 'onQueryExecuted']);
-        $events->listen('Illuminate\Cache\Events\CacheHit', [$this, 'onCacheHit']);
-        $events->listen('Illuminate\Cache\Events\CacheMissed', [$this, 'onCacheMissed']);
-        $events->listen('Illuminate\Cache\Events\KeyWritten', [$this, 'onCacheWritten']);
-        $events->listen('Illuminate\Cache\Events\KeyForgotten', [$this, 'onCacheForgotten']);
-        $events->listen('Illuminate\Queue\Events\JobQueued', [$this, 'onJobQueued']);
+        $events->listen(RouteMatched::class, $this->onRouteMatched(...));
+        $events->listen(QueryExecuted::class, $this->onQueryExecuted(...));
+        $events->listen(CacheHit::class, $this->onCacheHit(...));
+        $events->listen(CacheMissed::class, $this->onCacheMissed(...));
+        $events->listen(KeyWritten::class, $this->onCacheWritten(...));
+        $events->listen(KeyForgotten::class, $this->onCacheForgotten(...));
+        $events->listen(JobQueued::class, $this->onJobQueued(...));
 
         // Paired: the sending event only starts a timer, the sent event is what
         // records the message. A send that throws never reaches sent and leaves
         // only a mark that the next send overwrites.
-        $events->listen('Illuminate\Mail\Events\MessageSending', [$this, 'onMailSending']);
-        $events->listen('Illuminate\Mail\Events\MessageSent', [$this, 'onMailSent']);
-        $events->listen('Illuminate\Notifications\Events\NotificationSent', [$this, 'onNotificationSent']);
-        $events->listen('Illuminate\Notifications\Events\NotificationFailed', [$this, 'onNotificationFailed']);
+        $events->listen(MessageSending::class, $this->onMailSending(...));
+        $events->listen(MessageSent::class, $this->onMailSent(...));
+        $events->listen(NotificationSent::class, $this->onNotificationSent(...));
+        $events->listen(NotificationFailed::class, $this->onNotificationFailed(...));
 
-        // Outgoing HTTP, via the client's own event rather than Guzzle
-        // middleware: the event exists from Laravel 8 and needs no handler
-        // stack to be pushed onto a client we do not own.
-        $events->listen('Illuminate\Http\Client\Events\ResponseReceived', [$this, 'onOutgoingRequest']);
-        $events->listen('Illuminate\Http\Client\Events\ConnectionFailed', [$this, 'onOutgoingRequest']);
+        // Outgoing HTTP via the client's own events: no handler stack has to be
+        // pushed onto a Guzzle client we do not own.
+        $events->listen(ResponseReceived::class, $this->onOutgoingRequest(...));
+        $events->listen(ConnectionFailed::class, $this->onOutgoingRequest(...));
 
-        // Every log line written while this request was being served. The
-        // counter is what makes "this endpoint logs forty lines a request"
+        // The counter is what makes "this endpoint logs forty lines a request"
         // visible without storing forty lines against it.
-        $events->listen('Illuminate\Log\Events\MessageLogged', [$this, 'onMessageLogged']);
+        $events->listen(MessageLogged::class, $this->onMessageLogged(...));
     }
 
-    public function onRouteMatched($event): void
+    public function onRouteMatched(object $event): void
     {
         $this->guard(function () use ($event) {
             $route = $event->route;
@@ -83,14 +82,14 @@ class RequestListeners
                 'methods' => $route->methods(),
             ]);
 
-            // The decision was made before routing, because a trace has to
+            // The sampling decision predates routing, because a trace has to
             // start before there is a route to reason about. Now that there is
             // one, the ignore list gets its say.
             $this->sampler->reconsider($path);
         });
     }
 
-    public function onQueryExecuted($event): void
+    public function onQueryExecuted(object $event): void
     {
         $this->guard(function () use ($event) {
             if (! $this->sampler->decided()) {
@@ -105,7 +104,7 @@ class RequestListeners
         });
     }
 
-    public function onCacheHit($event): void
+    public function onCacheHit(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->monitor->increment('cache_hits');
@@ -113,7 +112,7 @@ class RequestListeners
         });
     }
 
-    public function onCacheMissed($event): void
+    public function onCacheMissed(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->monitor->increment('cache_misses');
@@ -121,14 +120,14 @@ class RequestListeners
         });
     }
 
-    public function onCacheWritten($event): void
+    public function onCacheWritten(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->recordCacheEvent('write', $event);
         });
     }
 
-    public function onCacheForgotten($event): void
+    public function onCacheForgotten(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->recordCacheEvent('forget', $event);
@@ -136,12 +135,10 @@ class RequestListeners
     }
 
     /**
-     * Buffer one cache operation. The key is narrowed to a prefix unless the
-     * application opted the full keys in; the ttl is only meaningful on a write.
-     *
-     * @param  mixed  $event
+     * The key is narrowed to a prefix unless the application opted the full
+     * keys in; the ttl is only meaningful on a write.
      */
-    private function recordCacheEvent(string $op, $event): void
+    private function recordCacheEvent(string $op, object $event): void
     {
         $this->monitor->recordCacheEvent([
             'op' => $op,
@@ -152,12 +149,11 @@ class RequestListeners
     }
 
     /**
-     * A cache key narrowed to what is safe to keep. Laravel's keys are routinely
-     * "prefix:id", and the prefix is the diagnostic part while the id is customer
-     * data; the part up to the first colon keeps the former and drops the latter.
-     * A key with no colon is bounded to a fixed length. An application that has
-     * decided its keys are safe keeps them whole, the same shape the payload
-     * capture takes.
+     * Laravel's keys are routinely "prefix:id", and the prefix is the
+     * diagnostic part while the id is customer data: the part up to the first
+     * colon keeps the former and drops the latter. A key with no colon is
+     * bounded to a fixed length; an application that opted in keeps its keys
+     * whole.
      */
     private function cacheKey(string $key): string
     {
@@ -174,24 +170,23 @@ class RequestListeners
         return mb_substr($key, 0, 64);
     }
 
-    public function onJobQueued($event): void
+    public function onJobQueued(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->monitor->increment('jobs_queued');
 
-            // A queued mailable is a job whose payload is the mailable itself,
-            // and its send happens a worker away where no request is being
-            // recorded. Caught here, at dispatch, it is counted against the
-            // request that queued it or it is never seen inside one at all.
+            // A queued mailable's send happens a worker away, where no request
+            // is being recorded. Counted at dispatch, it lands on the request
+            // that queued it — or is never seen inside one at all.
             $job = $event->job ?? null;
 
-            if ($job instanceof \Illuminate\Mail\SendQueuedMailable) {
+            if ($job instanceof SendQueuedMailable) {
                 $this->recordQueuedMail($job->mailable ?? null);
             }
         });
     }
 
-    public function onMailSending($event): void
+    public function onMailSending(object $event): void
     {
         $this->guard(function () use ($event) {
             if ($this->isNotificationMail($event)) {
@@ -208,12 +203,12 @@ class RequestListeners
         });
     }
 
-    public function onMailSent($event): void
+    public function onMailSent(object $event): void
     {
         $this->guard(function () use ($event) {
-            // A notification sent over mail fires this too, and the notification
-            // path already records it; bowing out here keeps it from counting as
-            // both a mail and a notification, the same split Nightwatch draws.
+            // A notification sent over mail fires this too, and the
+            // notification path already records it; bowing out keeps it from
+            // counting as both, the same split Nightwatch draws.
             if ($this->isNotificationMail($event)) {
                 return;
             }
@@ -246,19 +241,18 @@ class RequestListeners
     }
 
     /**
-     * The class of the mailable being sent, when there is one.
-     *
-     * Neither mail event carries it, so it is read off the call stack instead:
-     * a Mailable's send() is always a frame below the event that fires inside
-     * it. Empty for mail sent without a mailable — Mail::raw() and the like —
-     * where the subject is the only name a message has.
+     * Neither mail event carries the mailable, so it is read off the call
+     * stack instead: a Mailable's send() is always a frame below the event
+     * that fires inside it. Empty for mail sent without a mailable —
+     * Mail::raw() and the like — where the subject is the only name a
+     * message has.
      */
     private function mailableClass(): string
     {
         foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 50) as $frame) {
             $object = $frame['object'] ?? null;
 
-            if ($object instanceof \Illuminate\Mail\Mailable) {
+            if ($object instanceof Mailable) {
                 return get_class($object);
             }
         }
@@ -266,7 +260,7 @@ class RequestListeners
         return '';
     }
 
-    private function mailSubject($message): string
+    private function mailSubject(object $message): string
     {
         if (! method_exists($message, 'getSubject')) {
             return '';
@@ -276,14 +270,14 @@ class RequestListeners
     }
 
     /**
-     * One address list off a message, across mail engines. Symfony's Email has
-     * the getters and returns Address objects; the older Swift message had the
-     * same getter names and returned an [address => name] map. A version without
-     * the getter simply contributes nobody.
+     * One address list off a message, across mail engines: Symfony's Email has
+     * the getters and returns Address objects, the older Swift message had the
+     * same getter names and returned an [address => name] map, and a message
+     * without the getter contributes nobody.
      *
      * @return array<int|string, mixed>
      */
-    private function recipients($message, string $getter): array
+    private function recipients(object $message, string $getter): array
     {
         if (! method_exists($message, $getter)) {
             return [];
@@ -293,8 +287,8 @@ class RequestListeners
     }
 
     /**
-     * The address strings in a recipient list, whichever engine produced it.
-     * Symfony hands over Address objects; Swift keyed the address and put the
+     * The address strings in a recipient list, whichever engine produced it:
+     * Symfony hands over Address objects, Swift keyed the address and put the
      * name in the value.
      *
      * @param  array<int|string, mixed>  $recipients
@@ -326,13 +320,11 @@ class RequestListeners
     }
 
     /**
-     * What is stored for who a message went to: the domains it reached, deduped,
-     * and never the addresses themselves. The domain is the diagnostic part — a
-     * bounce is a bounce to gmail.com, not to a person — and the local part is
-     * the customer data the whole request position rests on not keeping.
-     *
-     * An application that has decided its recipients are safe to store opts the
-     * full addresses in, the same shape the payload capture takes.
+     * Stored as the domains a message reached, deduped, never the addresses:
+     * a bounce is a bounce to gmail.com, not to a person, and the local part
+     * is the customer data the whole request position rests on not keeping.
+     * Opting in capture_mail_recipients keeps the full addresses, the same
+     * shape the payload capture takes.
      *
      * @param  array<int, string>  $addresses
      */
@@ -361,11 +353,10 @@ class RequestListeners
     }
 
     /**
-     * How long the send took, when the sending event was seen for this same
-     * message. Zero when it was not: a mailer that only fires sent, or a message
-     * whose sending threw before the mark was read back.
+     * Zero when the sending event was never seen for this message: a mailer
+     * that only fires sent, or a send that threw before the mark was read back.
      */
-    private function mailDuration($message): float
+    private function mailDuration(object $message): float
     {
         $key = spl_object_id($message);
 
@@ -381,17 +372,14 @@ class RequestListeners
     }
 
     /**
-     * Record a mailable that was queued rather than sent inline.
-     *
-     * Read off the mailable the job carries, not off a message: there is no
-     * message yet, the send is a worker away. Its recipients are already filled
-     * in by the time it is queued, so the counts and domains are known; the
-     * subject often is not, since an envelope resolves it at render, and the
-     * duration cannot be, so both are left for the send that is not ours to see.
-     *
-     * @param  mixed  $mailable
+     * Record a mailable that was queued rather than sent inline, read off the
+     * mailable the job carries: there is no message yet, the send is a worker
+     * away. Recipients are filled in by queue time, so counts and domains are
+     * known; the subject often is not, since an envelope resolves it at
+     * render, and the duration cannot be, so both are left for the send that
+     * is not ours to see.
      */
-    private function recordQueuedMail($mailable): void
+    private function recordQueuedMail(mixed $mailable): void
     {
         if (! is_object($mailable)) {
             return;
@@ -414,14 +402,13 @@ class RequestListeners
     }
 
     /**
-     * The addresses in one of a mailable's recipient lists. A Mailable holds its
-     * to, cc and bcc as public arrays of ['name' => ..., 'address' => ...], which
-     * is a different shape from the message getters a sent message exposes.
+     * The addresses in one of a mailable's recipient lists. A Mailable holds
+     * its to, cc and bcc as public arrays of ['name' => ..., 'address' => ...],
+     * a different shape from the getters a sent message exposes.
      *
-     * @param  mixed  $mailable
      * @return array<int, string>
      */
-    private function mailableAddresses($mailable, string $property): array
+    private function mailableAddresses(object $mailable, string $property): array
     {
         $recipients = $mailable->{$property} ?? [];
 
@@ -446,14 +433,14 @@ class RequestListeners
         return $addresses;
     }
 
-    public function onNotificationSent($event): void
+    public function onNotificationSent(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->recordNotification($event, 1);
         });
     }
 
-    public function onNotificationFailed($event): void
+    public function onNotificationFailed(object $event): void
     {
         $this->guard(function () use ($event) {
             $this->recordNotification($event, 0);
@@ -462,10 +449,8 @@ class RequestListeners
 
     /**
      * Record one notification, one entry per channel.
-     *
-     * @param  mixed  $event
      */
-    private function recordNotification($event, int $success): void
+    private function recordNotification(object $event, int $success): void
     {
         $notification = $event->notification ?? null;
         $notifiable = $event->notifiable ?? null;
@@ -481,9 +466,9 @@ class RequestListeners
     }
 
     /**
-     * A class name with an anonymous marker trimmed off. An on-the-fly
-     * notification is an anonymous class, and get_class returns its file path
-     * after a null byte; the part before it is the only stable name it has.
+     * An on-the-fly notification is an anonymous class, and get_class returns
+     * its file path after a null byte; the part before it is the only stable
+     * name it has.
      */
     private function normalisedClass(string $class): string
     {
@@ -493,18 +478,16 @@ class RequestListeners
     }
 
     /**
-     * Whether a mail event is a notification going out over the mail channel.
+     * Whether a mail event is a notification going out over the mail channel:
      * Laravel stamps the notification on the event data, and the notification
      * path already records it, so the mail path leaves it alone.
-     *
-     * @param  mixed  $event
      */
-    private function isNotificationMail($event): bool
+    private function isNotificationMail(object $event): bool
     {
         return is_array($event->data ?? null) && isset($event->data['__laravel_notification']);
     }
 
-    public function onOutgoingRequest($event): void
+    public function onOutgoingRequest(object $event): void
     {
         $this->guard(function () use ($event) {
             $request = $event->request ?? null;
@@ -535,8 +518,8 @@ class RequestListeners
 
     /**
      * The url with its query values stripped, the names kept, the same stance
-     * the request path takes. Rebuilt rather than regexed so a value carrying an
-     * & or = of its own cannot smuggle itself back in.
+     * the request path takes. Rebuilt rather than regexed so a value carrying
+     * an & or = of its own cannot smuggle itself back in.
      */
     private function strippedUrl(string $url): string
     {
@@ -557,20 +540,16 @@ class RequestListeners
 
         parse_str($parts['query'], $params);
 
-        $names = implode('&', array_map(function ($key) {
-            return $key.'=';
-        }, array_keys($params)));
+        $names = implode('&', array_map(fn ($key) => $key.'=', array_keys($params)));
 
         return $names === '' ? $rebuilt : $rebuilt.'?'.$names;
     }
 
     /**
-     * The round trip in milliseconds, off Guzzle's transfer stats which the Http
-     * client hangs on the response. Zero when the call never got one.
-     *
-     * @param  mixed  $response
+     * The round trip in milliseconds, off Guzzle's transfer stats which the
+     * Http client hangs on the response. Zero when the call never got one.
      */
-    private function outgoingDuration($response): float
+    private function outgoingDuration(?object $response): float
     {
         if ($response === null) {
             return 0.0;
@@ -589,23 +568,21 @@ class RequestListeners
      * A short reason a call failed, for the ones that never got a response.
      * ConnectionFailed grew an exception in later Laravel; older versions carry
      * only the request, so a generic marker is the most that can be said.
-     *
-     * @param  mixed  $event
      */
-    private function outgoingError($event, bool $failed): string
+    private function outgoingError(object $event, bool $failed): string
     {
         if (! $failed) {
             return '';
         }
 
-        if (isset($event->exception) && $event->exception instanceof \Throwable) {
+        if (isset($event->exception) && $event->exception instanceof Throwable) {
             return mb_substr($event->exception->getMessage(), 0, 255);
         }
 
         return 'Connection failed';
     }
 
-    public function onMessageLogged($event): void
+    public function onMessageLogged(object $event): void
     {
         $this->guard(function () {
             $this->monitor->recordLog();
@@ -616,7 +593,7 @@ class RequestListeners
     {
         try {
             $callback();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             // Never let instrumentation surface in the application's own stack.
         }
     }

--- a/src/Requests/RequestMonitor.php
+++ b/src/Requests/RequestMonitor.php
@@ -2,6 +2,7 @@
 
 namespace LaraBug\Requests;
 
+use Throwable;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 class RequestMonitor
 {
     /** @var array<string, float> Wall-clock marks, in seconds. */
-    protected $marks = [];
+    protected array $marks = [];
 
     /** @var array<string, int> */
-    protected $counters = [
+    protected array $counters = [
         'queries' => 0,
         'cache_hits' => 0,
         'cache_misses' => 0,
@@ -38,43 +39,34 @@ class RequestMonitor
     ];
 
     /** @var array<int, array<string, mixed>> */
-    protected $queries = [];
+    protected array $queries = [];
 
     /** @var array<int, array<string, mixed>> */
-    protected $outgoing = [];
+    protected array $outgoing = [];
 
     /** @var array<int, array<string, mixed>> */
-    protected $mail = [];
+    protected array $mail = [];
 
     /** @var array<int, array<string, mixed>> */
-    protected $notifications = [];
+    protected array $notifications = [];
 
     /** @var array<int, array<string, mixed>> */
-    protected $cache = [];
+    protected array $cache = [];
 
     /** @var array<string, mixed>|null */
-    protected $route = null;
+    protected ?array $route = null;
 
-    /** @var string */
-    protected $exceptionId = '';
+    protected string $exceptionId = '';
 
-    /** @var array<string, mixed>|null */
-    protected $payload = null;
+    protected readonly int $maxQueries;
 
-    /** @var int */
-    protected $maxQueries;
+    protected readonly int $maxOutgoing;
 
-    /** @var int */
-    protected $maxOutgoing;
+    protected readonly int $maxMail;
 
-    /** @var int */
-    protected $maxMail;
+    protected readonly int $maxNotifications;
 
-    /** @var int */
-    protected $maxNotifications;
-
-    /** @var int */
-    protected $maxCacheEvents;
+    protected readonly int $maxCacheEvents;
 
     public function __construct()
     {
@@ -86,8 +78,7 @@ class RequestMonitor
 
         // LARAVEL_START is set in public/index.php before the framework boots,
         // so it is the only honest answer to "when did this request begin".
-        // Without it the earliest we can see is our own service provider, and
-        // bootstrap would report as nothing.
+        // Without it bootstrap would report as nothing.
         $this->marks['start'] = defined('LARAVEL_START') ? LARAVEL_START : microtime(true);
     }
 
@@ -122,11 +113,9 @@ class RequestMonitor
     }
 
     /**
-     * The exception this request threw, if the SDK reported one.
-     *
-     * Set from the report path rather than guessed from the status code: a 500
-     * can be returned deliberately, and an exception can be reported on a
-     * request that still answers 200.
+     * The exception this request threw, set from the report path rather than
+     * guessed from the status code: a 500 can be returned deliberately, and an
+     * exception can be reported on a request that still answers 200.
      */
     public function recordException(string $exceptionId = ''): void
     {
@@ -143,20 +132,18 @@ class RequestMonitor
     }
 
     /**
-     * Record one query.
-     *
      * The statement is kept with its placeholders and the bindings are dropped
-     * on the floor here rather than filtered later: a value in a WHERE clause is
-     * customer data, and the safest place to not send it is the place it would
+     * here rather than filtered later: a value in a WHERE clause is customer
+     * data, and the safest place to not send it is the place it would
      * otherwise be collected.
      */
     public function recordQuery(string $sql, string $connection, float $durationMs): void
     {
         $this->counters['queries']++;
 
-        // The counter keeps counting past the cap. A request running ten
-        // thousand queries is worth knowing about, and the reason to look at it
-        // is the number rather than the ten thousandth statement.
+        // The counter keeps counting past the cap: a request running ten
+        // thousand queries is worth knowing about, and the reason to look at
+        // it is the number rather than the ten thousandth statement.
         if (count($this->queries) >= $this->maxQueries) {
             return;
         }
@@ -172,13 +159,10 @@ class RequestMonitor
     }
 
     /**
-     * Record one outbound HTTP call.
-     *
-     * The counter keeps counting past the cap, the same as queries: a request
-     * that fans out to a hundred services is worth knowing about, and the number
-     * is what says so. The url arrives with its query values already stripped by
-     * the listener, the same stance the request path takes: a token in a
-     * callback url is customer data we have no business storing.
+     * Record one outbound HTTP call. The counter keeps counting past the cap,
+     * the same as queries. The url arrives with its query values already
+     * stripped by the listener: a token in a callback url is customer data we
+     * have no business storing.
      *
      * @param  array<string, mixed>  $call
      */
@@ -194,13 +178,10 @@ class RequestMonitor
     }
 
     /**
-     * Record one message sent.
-     *
-     * Carries the counter the same way recordOutgoing does, so the mail_sent
-     * tile still counts every message even on a request that sends more than the
-     * cap keeps. The recipients arrive as domains rather than addresses unless
-     * the application opted the full ones in: who a request emailed is personal
-     * data, and which service it emailed is the diagnostic part.
+     * Record one message sent. The counter keeps counting past the cap. The
+     * recipients arrive as domains rather than addresses unless the
+     * application opted the full ones in: who a request emailed is personal
+     * data, which service it emailed is the diagnostic part.
      *
      * @param  array<string, mixed>  $message
      */
@@ -216,12 +197,10 @@ class RequestMonitor
     }
 
     /**
-     * Record one notification sent.
-     *
-     * Carries the counter like recordMail does, one entry per channel: a
-     * notification going out over mail and database is two sends, which is what
-     * the notifiable actually receives. The notifiable is kept as its class,
-     * never its id: which model type gets notified is diagnostic, and which row
+     * Record one notification sent, one entry per channel: a notification
+     * going out over mail and database is two sends, which is what the
+     * notifiable actually receives. The notifiable is kept as its class,
+     * never its id: which model type gets notified is diagnostic, which row
      * is personal data.
      *
      * @param  array<string, mixed>  $notification
@@ -238,14 +217,10 @@ class RequestMonitor
     }
 
     /**
-     * Record one cache operation.
-     *
-     * The hit and miss counters are kept by their own listeners, so this only
-     * buffers the detail and is capped on its own: a request that reads the cache
-     * a thousand times is common, and the first hundred operations are enough to
-     * see its shape. The key arrives already narrowed to a prefix unless the
-     * application opted the full keys in, the same stance the query bindings take:
-     * a cache key routinely carries an id, which is customer data.
+     * Record one cache operation. The hit and miss counters are kept by their
+     * own listeners, so this only buffers the detail and is capped on its own:
+     * a request that reads the cache a thousand times is common, and the first
+     * hundred operations are enough to see its shape.
      *
      * @param  array<string, mixed>  $event
      */
@@ -281,8 +256,7 @@ class RequestMonitor
 
             // The path, and the names of the query parameters. Never their
             // values: password reset tokens, signed url signatures and invite
-            // tokens all live in a query string, and a customer who learns we
-            // stored one learns it too late.
+            // tokens all live in a query string.
             'path' => '/'.ltrim($request->path(), '/'),
             'query_keys' => implode(',', array_keys($request->query())),
 
@@ -328,10 +302,9 @@ class RequestMonitor
     }
 
     /**
-     * Request headers, minus the ones that are credentials.
-     *
-     * An allow-by-default list with an explicit deny, rather than the reverse:
-     * a header nobody thought about is usually diagnostic, and the handful that
+     * Request headers, minus the ones that are credentials. An
+     * allow-by-default list with an explicit deny, rather than the reverse: a
+     * header nobody thought about is usually diagnostic, and the handful that
      * are not are well known.
      *
      * @return string JSON
@@ -342,10 +315,10 @@ class RequestMonitor
             return '';
         }
 
-        // The fallback matters more than it looks. An application that
-        // published its config before these keys existed reads nothing from
-        // the file, and an empty list here would mean its Authorization header
-        // was stored in full. The default is the list, not the absence of one.
+        // The fallback matters: an application that published its config
+        // before these keys existed reads nothing from the file, and an empty
+        // list here would store its Authorization header in full. The default
+        // is the list, not the absence of one.
         $redact = array_map('strtolower', (array) config('larabug.requests.redact_headers', [
             'authorization',
             'cookie',
@@ -370,11 +343,9 @@ class RequestMonitor
     }
 
     /**
-     * The request body, on failure only.
-     *
-     * Nightwatch's bargain, and the right one: the body is what you need to
-     * reproduce the request that broke, and what you have no reason to hold for
-     * the thousands that did not.
+     * The request body, on failure only: the body is what you need to
+     * reproduce the request that broke, and what you have no reason to hold
+     * for the thousands that did not.
      */
     protected function payload(Request $request, Response $response): string
     {
@@ -404,12 +375,10 @@ class RequestMonitor
     }
 
     /**
-     * Replace sensitive values anywhere in a body.
-     *
-     * Depth-first and by substring, because the field that matters is rarely at
-     * the top level under exactly the name the config lists: a checkout posts
-     * card[cvv], a registration posts user.password_confirmation, and a rule
-     * that only reads the outermost keys would store both.
+     * Replace sensitive values anywhere in a body. Depth-first and by
+     * substring, because the field that matters is rarely at the top level
+     * under exactly the name the config lists: a checkout posts card[cvv], a
+     * registration posts user.password_confirmation.
      *
      * @param  array<int|string, mixed>  $input
      * @param  array<int, string>  $redact  lowercased needles
@@ -418,18 +387,17 @@ class RequestMonitor
     protected function redact(array $input, array $redact): array
     {
         foreach ($input as $key => $value) {
-            // The key is judged before the value is walked into. A matching key
-            // takes its whole branch with it: 'card' has to remove
-            // card[number] as well as card[cvv], and recursing first would only
-            // have caught the one that happened to be named in the list.
+            // The key is judged before the value is walked into: a matching
+            // key takes its whole branch with it, so 'card' removes
+            // card[number] as well as card[cvv].
             if ($this->isSensitive($key, $redact)) {
                 $input[$key] = '[redacted]';
 
                 continue;
             }
 
-            // An upload is a file handle, not data. It has no JSON form worth
-            // sending and its contents are not ours to hold, so it is described
+            // An upload is a file handle, not data: no JSON form worth sending
+            // and contents that are not ours to hold, so it is described
             // rather than serialised.
             if ($value instanceof UploadedFile) {
                 $input[$key] = '[file: '.$value->getClientOriginalName().']';
@@ -449,12 +417,12 @@ class RequestMonitor
      * @param  int|string  $key
      * @param  array<int, string>  $redact  lowercased needles
      */
-    protected function isSensitive($key, array $redact): bool
+    protected function isSensitive(int|string $key, array $redact): bool
     {
         $name = strtolower((string) $key);
 
         foreach ($redact as $needle) {
-            if ($needle !== '' && strpos($name, $needle) !== false) {
+            if ($needle !== '' && str_contains($name, $needle)) {
                 return true;
             }
         }
@@ -463,12 +431,11 @@ class RequestMonitor
     }
 
     /**
-     * The seven stages, in the order a request passes through them.
-     *
-     * Each is the gap between two marks, and a mark that was never set closes
-     * its stage at zero rather than borrowing from its neighbour: a request
-     * that threw in middleware never reached render, and reporting render time
-     * for it would be inventing a number.
+     * The seven stages, in the order a request passes through them. Each is
+     * the gap between two marks, and a mark that was never set closes its
+     * stage at zero rather than borrowing from its neighbour: a request that
+     * threw in middleware never reached render, and reporting render time for
+     * it would be inventing a number.
      *
      * @return array<string, float>
      */
@@ -487,7 +454,7 @@ class RequestMonitor
         $stages = [];
 
         foreach ($order as $stage => $pair) {
-            list($from, $to) = $pair;
+            [$from, $to] = $pair;
 
             $stages[$stage] = isset($this->marks[$from], $this->marks[$to])
                 ? round(max(0, ($this->marks[$to] - $this->marks[$from]) * 1000), 3)
@@ -498,11 +465,10 @@ class RequestMonitor
     }
 
     /**
-     * The rollup key, hashed here rather than on ingest.
-     *
-     * Sorted methods, domain and route path, which is Nightwatch's key and the
-     * right one: it groups by what the application defines rather than by what
-     * the client typed, so /users/1 and /users/2 are one row.
+     * The rollup key, hashed here rather than on ingest. Sorted methods,
+     * domain and route path, which is Nightwatch's key and the right one: it
+     * groups by what the application defines rather than by what the client
+     * typed, so /users/1 and /users/2 are one row.
      */
     protected function group(Request $request): string
     {
@@ -514,15 +480,12 @@ class RequestMonitor
 
         sort($methods);
 
-        // md5 for the same reason QueryNormaliser uses it: xxh128 is PHP 8.1+
-        // and this package still supports 7.4.
+        // md5 for the same reason QueryNormaliser keeps it: a stable grouping
+        // key, not a signature.
         return md5(implode('|', $methods).','.$this->routeValue('domain', '').','.$this->routeValue('path', ''));
     }
 
-    /**
-     * @return mixed
-     */
-    protected function routeValue(string $key, $default)
+    protected function routeValue(string $key, mixed $default): mixed
     {
         if ($this->route === null || ! array_key_exists($key, $this->route)) {
             return $default;
@@ -539,7 +502,7 @@ class RequestMonitor
 
         try {
             $user = auth()->user();
-        } catch (\Throwable $e) {
+        } catch (Throwable) {
             return '';
         }
 

--- a/src/Requests/Sampler.php
+++ b/src/Requests/Sampler.php
@@ -22,17 +22,14 @@ use Illuminate\Http\Request;
  */
 class Sampler
 {
-    /** @var float */
-    protected $rate;
+    protected readonly float $rate;
 
-    /** @var float */
-    protected $exceptionRate;
+    protected readonly float $exceptionRate;
 
     /** @var array<int, string> */
-    protected $ignore;
+    protected readonly array $ignore;
 
-    /** @var bool|null */
-    protected $decision = null;
+    protected ?bool $decision = null;
 
     public function __construct()
     {
@@ -96,9 +93,9 @@ class Sampler
      * A 5xx is kept far more often than head sampling implies: whatever the
      * coin did on arrival, it re-rolls at the exception rate, so at the default
      * 1.0 every failure is kept. Dividing by the head rate would then weight a
-     * failure by ten while it was really kept every time, counting ten failures
-     * where there was one and wrecking the error rate. Its true keep-chance is
-     * "head-sampled, or not and the exception re-roll kept it".
+     * failure by ten while it was really kept every time, wrecking the error
+     * rate. Its true keep-chance is "head-sampled, or not and the exception
+     * re-roll kept it".
      */
     public function rateForException(): float
     {

--- a/src/Requests/TraceContext.php
+++ b/src/Requests/TraceContext.php
@@ -15,27 +15,15 @@ namespace LaraBug\Requests;
  */
 class TraceContext
 {
-    /** @var string|null */
-    protected static $traceId = null;
+    protected static ?string $traceId = null;
 
     public static function id(): string
     {
-        if (self::$traceId === null) {
-            self::$traceId = self::generate();
-        }
-
-        return self::$traceId;
+        return self::$traceId ??= self::generate();
     }
 
     /**
-     * A time-ordered id, built here rather than taken from Str::orderedUuid().
-     *
-     * The framework helper routes through ramsey/uuid's COMB generator, which
-     * on the versions Laravel 6 and 7 resolve to needs moontoast/math to
-     * convert a 128 bit integer. This package supports those releases and is
-     * not going to add a dependency to make an id.
-     *
-     * The layout is the same bargain orderedUuid strikes: 48 bits of
+     * The layout is the same bargain Str::orderedUuid() strikes: 48 bits of
      * millisecond timestamp in front, random after, so ids sort by creation
      * and a range scan stays possible later.
      */

--- a/src/Scanners/ComposerLockScanner.php
+++ b/src/Scanners/ComposerLockScanner.php
@@ -28,18 +28,20 @@ class ComposerLockScanner
         }
 
         $raw = file_get_contents($path);
+
         if ($raw === false) {
             return null;
         }
 
         $data = json_decode($raw, true);
+
         if (! is_array($data)) {
             return null;
         }
 
         $packages = $this->extractPackages($data, $includeDev);
 
-        if (empty($packages)) {
+        if ($packages === []) {
             return null;
         }
 
@@ -54,6 +56,7 @@ class ComposerLockScanner
     }
 
     /**
+     * @param  array<string, mixed>  $lock
      * @return array<string, string>
      */
     protected function extractPackages(array $lock, bool $includeDev): array
@@ -77,6 +80,9 @@ class ComposerLockScanner
         return $packages;
     }
 
+    /**
+     * @param  array<string, mixed>  $lock
+     */
     protected function extractPhpVersion(array $lock): ?string
     {
         $platform = $lock['platform'] ?? [];
@@ -85,11 +91,7 @@ class ComposerLockScanner
             return (string) $platform['php'];
         }
 
-        if (defined('PHP_VERSION')) {
-            return PHP_VERSION;
-        }
-
-        return null;
+        return PHP_VERSION;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,52 +2,69 @@
 
 namespace LaraBug;
 
-use LaraBug\Queue\DispatchMacros;
+use Throwable;
 use Monolog\Logger;
-use LaraBug\Commands\HeartbeatCommand;
+use SplObjectStorage;
+use LaraBug\Http\Client;
+use LaraBug\Support\Dsn;
+use InvalidArgumentException;
+use LaraBug\Logger\LogBuffer;
+use LaraBug\Queue\JobMonitor;
+use LaraBug\Requests\Sampler;
+use Illuminate\Log\LogManager;
+use LaraBug\Cve\RequestTrigger;
 use LaraBug\Commands\ScanCommand;
 use LaraBug\Commands\TestCommand;
-use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Contracts\Debug\ExceptionHandler;
+use LaraBug\Queue\DispatchMacros;
+use LaraBug\Console\CommandBuffer;
+use LaraBug\Logger\LaraBugHandler;
+use LaraBug\Requests\RequestBuffer;
+use LaraBug\Requests\RequestMonitor;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
+use LaraBug\Console\CommandListeners;
+use LaraBug\Logger\LaraBugLogHandler;
+use LaraBug\Queue\JobEventSubscriber;
+use Illuminate\Foundation\AliasLoader;
+use LaraBug\Commands\HeartbeatCommand;
+use LaraBug\Requests\RequestListeners;
+use Illuminate\Console\Scheduling\Event;
+use LaraBug\Console\ScheduledTaskBuffer;
+use Illuminate\Console\Scheduling\Schedule;
+use LaraBug\Console\ScheduledTaskListeners;
+use LaraBug\Http\Middleware\CaptureRequest;
+use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
-use Throwable;
 
 class ServiceProvider extends BaseServiceProvider
 {
-    /**
-     * Bootstrap the application events.
-     */
-    public function boot()
+    /** Handlers that already carry our reportable callback. */
+    protected SplObjectStorage $handlersRegistered;
+
+    public function boot(): void
     {
-        // Publish configuration file
         if (function_exists('config_path')) {
             $this->publishes([
                 __DIR__ . '/../config/larabug.php' => config_path('larabug.php'),
             ]);
         }
 
-        // Register views
         $this->app['view']->addNamespace('larabug', __DIR__ . '/../resources/views');
 
-        // Register facade
-        if (class_exists(\Illuminate\Foundation\AliasLoader::class)) {
-            $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-            $loader->alias('LaraBug', 'LaraBug\Facade');
+        if (class_exists(AliasLoader::class)) {
+            AliasLoader::getInstance()->alias('LaraBug', Facade::class);
         }
 
-        // Register commands
         $this->commands([
             TestCommand::class,
             ScanCommand::class,
             HeartbeatCommand::class,
         ]);
 
-        // Map any routes
         $this->mapLaraBugApiRoutes();
 
-        // Create an alias to the larabug-js-client.blade.php include
         Blade::include('larabug::larabug-js-client', 'larabugJavaScriptClient');
 
         // Report exceptions without every application having to wire LaraBug
@@ -73,8 +90,8 @@ class ServiceProvider extends BaseServiceProvider
         // this a request that logs less than one batch ships nothing, which is
         // most requests. Monolog's own close() covers the CLI case.
         $this->app->terminating(function () {
-            if ($this->app->resolved(\LaraBug\Logger\LogBuffer::class)) {
-                $this->app[\LaraBug\Logger\LogBuffer::class]->flush();
+            if ($this->app->resolved(LogBuffer::class)) {
+                $this->app[LogBuffer::class]->flush();
             }
         });
 
@@ -83,30 +100,28 @@ class ServiceProvider extends BaseServiceProvider
         // and running first would fold every other middleware into the action.
         if (config('larabug.requests.track_requests', false) && ! $this->app->runningInConsole()) {
             try {
-                $this->app->make(\Illuminate\Contracts\Http\Kernel::class)
-                    ->pushMiddleware(\LaraBug\Http\Middleware\CaptureRequest::class);
+                $this->app->make(Kernel::class)->pushMiddleware(CaptureRequest::class);
 
-                $this->app['events']->subscribe(\LaraBug\Requests\RequestListeners::class);
-            } catch (\Throwable $e) {
+                $this->app['events']->subscribe(RequestListeners::class);
+            } catch (Throwable) {
                 // An application with no HTTP kernel, or one that resolves it
                 // differently, simply does not get request monitoring.
             }
         }
 
-        // Register queue monitoring events
         if (config('larabug.jobs.track_jobs', true)) {
-            $this->app['events']->subscribe(\LaraBug\Queue\JobEventSubscriber::class);
+            $this->app['events']->subscribe(JobEventSubscriber::class);
         }
 
         // Command monitoring. The inverse of request monitoring: a command runs
         // in the console, so this is not gated behind runningInConsole.
         if (config('larabug.commands.track_commands', false)) {
-            $this->app['events']->subscribe(\LaraBug\Console\CommandListeners::class);
+            $this->app['events']->subscribe(CommandListeners::class);
         }
 
         // Scheduled task monitoring, the same context as commands.
         if (config('larabug.schedule.track_scheduled_tasks', false)) {
-            $this->app['events']->subscribe(\LaraBug\Console\ScheduledTaskListeners::class);
+            $this->app['events']->subscribe(ScheduledTaskListeners::class);
         }
 
         // The heartbeat only has a job to do where the scheduler runs, which is
@@ -125,7 +140,6 @@ class ServiceProvider extends BaseServiceProvider
             });
         }
 
-        // CVE triggers
         if (config('larabug.cve.enabled', false)) {
             $trigger = strtolower((string) config('larabug.cve.trigger', 'both'));
 
@@ -148,8 +162,8 @@ class ServiceProvider extends BaseServiceProvider
             if (in_array($trigger, ['request', 'both'], true) && ! $this->app->runningInConsole()) {
                 $this->app->terminating(function () {
                     try {
-                        $this->app->make(\LaraBug\Cve\RequestTrigger::class)->maybeTrigger();
-                    } catch (\Throwable $e) {
+                        $this->app->make(RequestTrigger::class)->maybeTrigger();
+                    } catch (Throwable) {
                         // Never let CVE scanning break the user's app.
                     }
                 });
@@ -157,61 +171,32 @@ class ServiceProvider extends BaseServiceProvider
         }
     }
 
-    /**
-     * switch, not match, for the same reason applyCadence below uses one: this
-     * package still supports PHP 7.4, where a match expression will not parse.
-     */
-    protected function applyHeartbeatCadence($event, string $cadence): void
+    protected function applyHeartbeatCadence(Event $event, string $cadence): void
     {
-        switch (strtolower($cadence)) {
-            case 'everytwominutes':
-                $event->everyTwoMinutes();
-                break;
-            case 'everyfiveminutes':
-                $event->everyFiveMinutes();
-                break;
-            case 'everytenminutes':
-                $event->everyTenMinutes();
-                break;
-            default:
-                $event->everyMinute();
-        }
+        match (strtolower($cadence)) {
+            'everytwominutes' => $event->everyTwoMinutes(),
+            'everyfiveminutes' => $event->everyFiveMinutes(),
+            'everytenminutes' => $event->everyTenMinutes(),
+            default => $event->everyMinute(),
+        };
     }
 
-    protected function applyCadence($event, string $cadence): void
+    protected function applyCadence(Event $event, string $cadence): void
     {
-        // switch, not match: this package still supports PHP 7.4, where a match
-        // expression is a parse error. The provider loads in every test, so it
-        // would take the whole suite down rather than just this path.
-        switch (strtolower($cadence)) {
-            case 'hourly':
-                $event->hourly();
-                break;
-            case 'twice-daily':
-            case 'twicedaily':
-                $event->twiceDaily();
-                break;
-            case 'daily':
-                $event->daily();
-                break;
-            default:
-                $event->cron($cadence);
-        }
+        match (strtolower($cadence)) {
+            'hourly' => $event->hourly(),
+            'twice-daily', 'twicedaily' => $event->twiceDaily(),
+            'daily' => $event->daily(),
+            default => $event->cron($cadence),
+        };
     }
-
-    /**
-     * Handlers that already carry our reportable callback.
-     *
-     * @var \SplObjectStorage
-     */
-    protected $handlersRegistered;
 
     /**
      * Report every reported exception to LaraBug.
      */
     protected function registerExceptionHandler(): void
     {
-        $this->handlersRegistered = new \SplObjectStorage();
+        $this->handlersRegistered = new SplObjectStorage();
 
         $this->callAfterResolving(ExceptionHandler::class, function ($handler) {
             // A handler that does not extend Laravel's own has no reportable(),
@@ -239,83 +224,64 @@ class ServiceProvider extends BaseServiceProvider
         });
     }
 
-    /**
-     * Register the service provider.
-     */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/larabug.php', 'larabug');
 
-        // Register the HTTP Client as a singleton
-        $this->app->singleton(\LaraBug\Http\Client::class, function ($app) {
-            // Check if DSN is configured and valid
+        $this->app->singleton(Client::class, function () {
             $dsn = config('larabug.dsn');
-            
-            if ($dsn && is_string($dsn) && trim($dsn) !== '' && \LaraBug\Support\Dsn::isValid($dsn)) {
-                try {
-                    $parsed = \LaraBug\Support\Dsn::make($dsn);
 
-                    // Override config values with DSN values
+            if ($dsn && is_string($dsn) && trim($dsn) !== '' && Dsn::isValid($dsn)) {
+                try {
+                    $parsed = Dsn::make($dsn);
+
+                    // The DSN wins over the individual config keys.
                     config(['larabug.login_key' => $parsed->getLoginKey()]);
                     config(['larabug.project_key' => $parsed->getProjectKey()]);
                     config(['larabug.server' => $parsed->getServer()]);
 
-                    return new \LaraBug\Http\Client(
+                    return new Client(
                         $parsed->getLoginKey(),
                         $parsed->getProjectKey()
                     );
-                } catch (\InvalidArgumentException $e) {
-                    // DSN parsing failed, fall back to individual config keys
+                } catch (InvalidArgumentException) {
+                    // DSN parsing failed, fall back to the individual config keys.
                 }
             }
 
-            // Fallback to individual config keys
-            return new \LaraBug\Http\Client(
+            return new Client(
                 config('larabug.login_key', 'login_key'),
                 config('larabug.project_key', 'project_key')
             );
         });
 
-        // Register the main LaraBug instance
-        $this->app->singleton('larabug', function ($app) {
-            return new LaraBug($app[\LaraBug\Http\Client::class]);
-        });
+        $this->app->singleton('larabug', fn ($app) => new LaraBug($app[Client::class]));
 
         // Log shipping buffer. Bound lazily, so an app that never adds the
         // channel never builds one.
-        $this->app->singleton(\LaraBug\Logger\LogBuffer::class, function ($app) {
-            return new \LaraBug\Logger\LogBuffer(
-                $app[\LaraBug\Http\Client::class],
-                $app['config']->get('larabug', [])
-            );
-        });
+        $this->app->singleton(LogBuffer::class, fn ($app) => new LogBuffer(
+            $app[Client::class],
+            $app['config']->get('larabug', [])
+        ));
 
-        if ($this->app['log'] instanceof \Illuminate\Log\LogManager) {
-            $this->app['log']->extend('larabug', function ($app, $config) {
-                $handler = new \LaraBug\Logger\LaraBugHandler(
-                    $app['larabug']
-                );
-
-                return new Logger('larabug', [$handler]);
-            });
+        if ($this->app['log'] instanceof LogManager) {
+            $this->app['log']->extend('larabug', fn ($app, $config) => new Logger('larabug', [
+                new LaraBugHandler($app['larabug']),
+            ]));
 
             $this->app['log']->extend('larabug-logs', function ($app, $config) {
                 $larabug = $app['config']->get('larabug', []);
 
-                $handler = new \LaraBug\Logger\LaraBugLogHandler(
-                    $app[\LaraBug\Logger\LogBuffer::class],
+                $handler = new LaraBugLogHandler(
+                    $app[LogBuffer::class],
                     [
-                        'logs' => isset($larabug['logs']) ? $larabug['logs'] : [],
+                        'logs' => $larabug['logs'] ?? [],
                         'environment' => $app['config']->get('app.env', ''),
-                        'release' => isset($larabug['logs']['release']) ? $larabug['logs']['release'] : '',
+                        'release' => $larabug['logs']['release'] ?? '',
                     ],
                     // The channel's own level wins, so a stack can ship warnings
                     // to us while writing everything to disk.
-                    Logger::toMonologLevel(
-                        isset($config['level'])
-                            ? $config['level']
-                            : (isset($larabug['logs']['level']) ? $larabug['logs']['level'] : 'info')
-                    )
+                    Logger::toMonologLevel($config['level'] ?? $larabug['logs']['level'] ?? 'info')
                 );
 
                 return new Logger('larabug-logs', [$handler]);
@@ -325,50 +291,42 @@ class ServiceProvider extends BaseServiceProvider
         // Request monitoring. One of each per execution: the monitor holds the
         // state of the request being served, the sampler holds the decision
         // made about it, and the buffer outlives both to flush on shutdown.
-        $this->app->singleton(\LaraBug\Requests\RequestMonitor::class);
-        $this->app->singleton(\LaraBug\Requests\Sampler::class);
+        $this->app->singleton(RequestMonitor::class);
+        $this->app->singleton(Sampler::class);
 
-        $this->app->singleton(\LaraBug\Requests\RequestBuffer::class, function ($app) {
-            return new \LaraBug\Requests\RequestBuffer(
-                $app->make(\LaraBug\Http\Client::class),
-                config('larabug')
-            );
-        });
+        $this->app->singleton(RequestBuffer::class, fn ($app) => new RequestBuffer(
+            $app->make(Client::class),
+            config('larabug')
+        ));
 
-        $this->app->singleton(\LaraBug\Console\CommandBuffer::class, function ($app) {
-            return new \LaraBug\Console\CommandBuffer(
-                $app->make(\LaraBug\Http\Client::class),
-                config('larabug')
-            );
-        });
+        $this->app->singleton(CommandBuffer::class, fn ($app) => new CommandBuffer(
+            $app->make(Client::class),
+            config('larabug')
+        ));
 
-        $this->app->singleton(\LaraBug\Console\ScheduledTaskBuffer::class, function ($app) {
-            return new \LaraBug\Console\ScheduledTaskBuffer(
-                $app->make(\LaraBug\Http\Client::class),
-                config('larabug')
-            );
-        });
+        $this->app->singleton(ScheduledTaskBuffer::class, fn ($app) => new ScheduledTaskBuffer(
+            $app->make(Client::class),
+            config('larabug')
+        ));
 
-        // Register queue monitoring singleton (always, will be lazy loaded)
-        $this->app->singleton(\LaraBug\Queue\JobMonitor::class, function ($app) {
-            return new \LaraBug\Queue\JobMonitor(
-                $app[\LaraBug\Http\Client::class],
-                $app['config']->get('larabug', [])
-            );
-        });
+        // Always bound; only built when job tracking first touches it.
+        $this->app->singleton(JobMonitor::class, fn ($app) => new JobMonitor(
+            $app[Client::class],
+            $app['config']->get('larabug', [])
+        ));
 
         // Only register macros if supported (Laravel < 11)
-        if (method_exists(\Illuminate\Foundation\Bus\PendingDispatch::class, 'macro')) {
+        if (method_exists(PendingDispatch::class, 'macro')) {
             DispatchMacros::register();
         }
     }
 
-    protected function mapLaraBugApiRoutes()
+    protected function mapLaraBugApiRoutes(): void
     {
         Route::group(
             [
                 'namespace' => '\LaraBug\Http\Controllers',
-                'prefix' => 'larabug-api'
+                'prefix' => 'larabug-api',
             ],
             function ($router) {
                 require __DIR__ . '/../routes/api.php';

--- a/src/Support/Dsn.php
+++ b/src/Support/Dsn.php
@@ -2,11 +2,15 @@
 
 namespace LaraBug\Support;
 
+use InvalidArgumentException;
+
 class Dsn
 {
-    protected string $loginKey;
-    protected string $projectKey;
-    protected string $server;
+    protected readonly string $loginKey;
+
+    protected readonly string $projectKey;
+
+    protected readonly string $server;
 
     public function __construct(string $dsn)
     {
@@ -14,7 +18,7 @@ class Dsn
     }
 
     /**
-     * Parse DSN string into components
+     * Parse a DSN string into components.
      * Format: https://login-key:project-key@host/path
      * Example: https://abc123:def456@www.larabug.com/api/log
      */
@@ -22,8 +26,8 @@ class Dsn
     {
         $parsed = parse_url($dsn);
 
-        if ($parsed === false || !isset($parsed['scheme'], $parsed['user'], $parsed['pass'], $parsed['host'])) {
-            throw new \InvalidArgumentException(
+        if ($parsed === false || ! isset($parsed['scheme'], $parsed['user'], $parsed['pass'], $parsed['host'])) {
+            throw new InvalidArgumentException(
                 'Invalid DSN format. Expected format: https://login-key:project-key@host/path'
             );
         }
@@ -31,7 +35,6 @@ class Dsn
         $this->loginKey = $parsed['user'];
         $this->projectKey = $parsed['pass'];
 
-        // Reconstruct server URL
         $this->server = sprintf(
             '%s://%s%s',
             $parsed['scheme'],
@@ -40,47 +43,33 @@ class Dsn
         );
     }
 
-    /**
-     * Get the login key
-     */
     public function getLoginKey(): string
     {
         return $this->loginKey;
     }
 
-    /**
-     * Get the project key
-     */
     public function getProjectKey(): string
     {
         return $this->projectKey;
     }
 
-    /**
-     * Get the server URL
-     */
     public function getServer(): string
     {
         return $this->server;
     }
 
-    /**
-     * Create DSN instance from string
-     */
-    public static function make(string $dsn): self
+    public static function make(string $dsn): static
     {
         return new static($dsn);
     }
 
-    /**
-     * Check if a string is a valid DSN format
-     */
     public static function isValid(string $dsn): bool
     {
         try {
             new static($dsn);
+
             return true;
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return false;
         }
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,15 +1,15 @@
 <?php
 
-if (!function_exists('dispatch_tracked')) {
+use Illuminate\Foundation\Bus\PendingDispatch;
+
+if (! function_exists('dispatch_tracked')) {
     /**
-     * Dispatch a job with LaraBug tracking enabled
-     * 
-     * @param object $job
-     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     * Dispatch a job with LaraBug tracking enabled.
      */
-    function dispatch_tracked($job)
+    function dispatch_tracked(object $job): PendingDispatch
     {
         $job->trackInLaraBug = true;
+
         return dispatch($job);
     }
 }

--- a/tests/CommandMonitoringTest.php
+++ b/tests/CommandMonitoringTest.php
@@ -4,10 +4,11 @@ namespace LaraBug\Tests;
 
 use LaraBug\Console\CommandBuffer;
 use LaraBug\Console\CommandListeners;
+use PHPUnit\Framework\Attributes\Test;
 
 class CommandMonitoringTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_records_a_finished_command_with_its_exit_code_and_arguments()
     {
         config(['larabug.commands.redact' => ['password']]);
@@ -32,12 +33,11 @@ class CommandMonitoringTest extends TestCase
         // The command name is the record's own column, not an argument.
         $this->assertArrayNotHasKey('command', $arguments['arguments']);
         $this->assertSame('mysql', $arguments['arguments']['connection']);
-        // The password option is replaced with a marker.
         $this->assertSame('[redacted]', $arguments['options']['password']);
         $this->assertTrue($arguments['options']['force']);
     }
 
-    /** @test */
+    #[Test]
     public function it_does_not_record_an_ignored_command()
     {
         config(['larabug.commands.ignore' => ['queue:work', 'horizon:*']]);
@@ -52,7 +52,7 @@ class CommandMonitoringTest extends TestCase
         $this->assertCount(0, $buffer->records);
     }
 
-    /** @test */
+    #[Test]
     public function a_failing_command_carries_its_non_zero_exit_code()
     {
         $buffer = $this->recordingBuffer();
@@ -65,15 +65,14 @@ class CommandMonitoringTest extends TestCase
         $this->assertSame(1, $buffer->records[0]['exit_code']);
     }
 
-    /** @test */
+    #[Test]
     public function nested_commands_each_get_their_own_record()
     {
         $buffer = $this->recordingBuffer();
         $listeners = new CommandListeners($buffer);
         $input = $this->fakeInput([], []);
 
-        // An outer command calls an inner one: starting, starting, finished,
-        // finished. Each finish must match the start it belongs to.
+        // Starting, starting, finished, finished: each finish must match the start it belongs to.
         $listeners->onCommandStarting($this->startingEvent('app:outer', $input));
         $listeners->onCommandStarting($this->startingEvent('app:inner', $input));
         $listeners->onCommandFinished($this->finishedEvent('app:inner', 0, $input));
@@ -84,12 +83,10 @@ class CommandMonitoringTest extends TestCase
 
     private function recordingBuffer(): CommandBuffer
     {
-        // A buffer that records rather than sends. It skips the parent
-        // constructor, so no shutdown flush is registered and no client is
-        // needed for a test that only cares what was buffered.
-        return new class extends CommandBuffer {
+        // Skips the parent constructor, so no shutdown flush is registered and no client is needed.
+        return new class () extends CommandBuffer {
             /** @var array<int, array<string, mixed>> */
-            public $records = [];
+            public array $records = [];
 
             public function __construct()
             {
@@ -130,17 +127,11 @@ class CommandMonitoringTest extends TestCase
      */
     private function fakeInput(array $arguments, array $options): object
     {
-        return new class($arguments, $options) {
-            /** @var array<string, mixed> */
-            private $arguments;
-
-            /** @var array<string, mixed> */
-            private $options;
-
-            public function __construct(array $arguments, array $options)
-            {
-                $this->arguments = $arguments;
-                $this->options = $options;
+        return new class ($arguments, $options) {
+            public function __construct(
+                private array $arguments,
+                private array $options,
+            ) {
             }
 
             /** @return array<string, mixed> */

--- a/tests/ComposerLockScannerTest.php
+++ b/tests/ComposerLockScannerTest.php
@@ -2,12 +2,12 @@
 
 namespace LaraBug\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use LaraBug\Scanners\ComposerLockScanner;
 
 class ComposerLockScannerTest extends TestCase
 {
-    /** @var string */
-    protected $lockPath;
+    protected string $lockPath;
 
     public function setUp(): void
     {
@@ -26,14 +26,14 @@ class ComposerLockScannerTest extends TestCase
     }
 
     /** @return array<string, mixed>|null */
-    protected function scan(array $lock, bool $includeDev = false, ?string $environment = null)
+    protected function scan(array $lock, bool $includeDev = false, ?string $environment = null): ?array
     {
         file_put_contents($this->lockPath, json_encode($lock));
 
         return (new ComposerLockScanner())->scan($this->lockPath, $includeDev, $environment);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_when_the_lockfile_does_not_exist()
     {
         $scanner = new ComposerLockScanner();
@@ -41,7 +41,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertNull($scanner->scan('/tmp/a-lockfile-that-is-not-there.lock'));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_when_the_lockfile_is_not_json()
     {
         file_put_contents($this->lockPath, 'this is not json');
@@ -49,13 +49,13 @@ class ComposerLockScannerTest extends TestCase
         $this->assertNull((new ComposerLockScanner())->scan($this->lockPath));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_when_there_are_no_packages()
     {
         $this->assertNull($this->scan(['packages' => []]));
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_package_names_and_versions()
     {
         $result = $this->scan([
@@ -71,7 +71,7 @@ class ComposerLockScannerTest extends TestCase
         ], $result['packages']);
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_packages_missing_a_name_or_version()
     {
         $result = $this->scan([
@@ -85,7 +85,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertSame(['laravel/framework' => 'v12.0.1'], $result['packages']);
     }
 
-    /** @test */
+    #[Test]
     public function it_ignores_dev_packages_unless_asked_for_them()
     {
         $lock = [
@@ -97,7 +97,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertArrayHasKey('phpunit/phpunit', $this->scan($lock, true)['packages']);
     }
 
-    /** @test */
+    #[Test]
     public function it_hashes_the_raw_lockfile_so_an_unchanged_lockfile_is_recognisable()
     {
         $lock = ['packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.1']]];
@@ -111,7 +111,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertSame(64, strlen($first['content_hash']));
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_the_framework_and_its_version()
     {
         $laravel = $this->scan(['packages' => [['name' => 'laravel/framework', 'version' => 'v12.0.1']]]);
@@ -129,7 +129,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertNull($neither['framework']);
     }
 
-    /** @test */
+    #[Test]
     public function it_prefers_the_php_version_the_lockfile_pins()
     {
         $pinned = $this->scan([
@@ -144,7 +144,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertSame(PHP_VERSION, $unpinned['php_version']);
     }
 
-    /** @test */
+    #[Test]
     public function it_takes_the_environment_it_is_given_over_the_configured_one()
     {
         $this->app['config']['app.env'] = 'local';
@@ -155,7 +155,7 @@ class ComposerLockScannerTest extends TestCase
         $this->assertSame('production', $this->scan($lock, false, 'production')['environment']);
     }
 
-    /** @test */
+    #[Test]
     public function it_never_sends_anything_beyond_names_versions_and_a_hash()
     {
         $result = $this->scan([

--- a/tests/CveRequestTriggerTest.php
+++ b/tests/CveRequestTriggerTest.php
@@ -2,15 +2,15 @@
 
 namespace LaraBug\Tests;
 
-use LaraBug\Cve\RequestTrigger;
-use LaraBug\Scanners\ComposerLockScanner;
-use LaraBug\Tests\Mocks\CveClient;
 use ReflectionClass;
+use LaraBug\Cve\RequestTrigger;
+use LaraBug\Tests\Mocks\CveClient;
+use PHPUnit\Framework\Attributes\Test;
+use LaraBug\Scanners\ComposerLockScanner;
 
 class CveRequestTriggerTest extends TestCase
 {
-    /** @var string */
-    protected $lockPath;
+    protected string $lockPath;
 
     public function setUp(): void
     {
@@ -24,8 +24,7 @@ class CveRequestTriggerTest extends TestCase
         $this->app['config']['larabug.cve.lock_path'] = $this->lockPath;
         $this->app['config']['larabug.cve.request_throttle_hours'] = 24;
 
-        // The trigger memoises per process; without this each test would inherit
-        // the previous one's "already fired" and cached payload.
+        // The trigger memoises per process; without a reset each test would inherit the previous one's state.
         $this->resetStaticState();
     }
 
@@ -45,9 +44,7 @@ class CveRequestTriggerTest extends TestCase
         $reflection = new ReflectionClass(RequestTrigger::class);
 
         foreach (['cachedPayload' => null, 'alreadyFired' => false] as $name => $value) {
-            $property = $reflection->getProperty($name);
-            $property->setAccessible(true);
-            $property->setValue(null, $value);
+            $reflection->getProperty($name)->setValue(null, $value);
         }
     }
 
@@ -63,7 +60,7 @@ class CveRequestTriggerTest extends TestCase
         return new RequestTrigger($this->app['cache']->store('array'), new ComposerLockScanner(), $client);
     }
 
-    /** @test */
+    #[Test]
     public function it_does_nothing_when_the_feature_is_disabled()
     {
         $this->app['config']['larabug.cve.enabled'] = false;
@@ -74,7 +71,7 @@ class CveRequestTriggerTest extends TestCase
         $client->assertRequestsSent(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_does_nothing_when_the_trigger_is_scheduled_only()
     {
         $this->app['config']['larabug.cve.trigger'] = 'schedule';
@@ -85,7 +82,7 @@ class CveRequestTriggerTest extends TestCase
         $client->assertRequestsSent(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_sends_the_lockfile_payload_tagged_as_a_cve_scan()
     {
         $client = new CveClient();
@@ -100,7 +97,7 @@ class CveRequestTriggerTest extends TestCase
         $this->assertSame(64, strlen($sent['composer_lock']['content_hash']));
     }
 
-    /** @test */
+    #[Test]
     public function it_only_fires_once_per_process()
     {
         $client = new CveClient();
@@ -113,7 +110,7 @@ class CveRequestTriggerTest extends TestCase
         $client->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_stays_quiet_while_the_lockfile_is_unchanged_and_the_throttle_holds()
     {
         $first = new CveClient();
@@ -129,7 +126,7 @@ class CveRequestTriggerTest extends TestCase
         $second->assertRequestsSent(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_again_as_soon_as_the_lockfile_changes()
     {
         $first = new CveClient();
@@ -145,7 +142,7 @@ class CveRequestTriggerTest extends TestCase
         $second->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_again_once_the_throttle_has_expired()
     {
         $first = new CveClient();
@@ -167,7 +164,7 @@ class CveRequestTriggerTest extends TestCase
         $second->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_remembers_a_scan_the_server_says_it_already_has()
     {
         $client = new CveClient(200, '{"skipped":"unchanged","snapshot_id":"snap-1"}');
@@ -176,11 +173,10 @@ class CveRequestTriggerTest extends TestCase
         $this->assertSame(64, strlen($this->app['cache']->store('array')->get('larabug.cve.last_sent_hash')));
     }
 
-    /** @test */
+    #[Test]
     public function it_does_not_remember_a_rejected_scan_as_a_success()
     {
-        // A 403 must not look like a delivered scan: the lockfile it describes
-        // has not been recorded, so nothing should claim it has.
+        // A 403 must not look like a delivered scan; nothing may claim its lockfile was recorded.
         $client = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
         $this->trigger($client)->maybeTrigger();
 
@@ -188,11 +184,10 @@ class CveRequestTriggerTest extends TestCase
         $this->assertNull($this->app['cache']->store('array')->get('larabug.cve.last_sent_hash'));
     }
 
-    /** @test */
+    #[Test]
     public function it_is_on_for_a_config_that_predates_the_feature()
     {
-        // A config file published before CVE scanning existed has no cve.enabled
-        // key at all. Scanning is opt-out, so an absent key still scans.
+        // A config published before the feature has no cve.enabled key; scanning is opt-out, so an absent key still scans.
         $cve = $this->app['config']['larabug.cve'];
         unset($cve['enabled']);
         $this->app['config']['larabug.cve'] = $cve;
@@ -205,12 +200,10 @@ class CveRequestTriggerTest extends TestCase
         $client->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_backs_off_after_a_403_instead_of_asking_on_every_request()
     {
-        // Being on by default means most apps meet a project that has not
-        // enabled scanning. Without a backoff every request would post the
-        // lockfile again to collect the same 403.
+        // Without a backoff, every request would post the lockfile again to collect the same 403.
         $rejected = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
         $this->trigger($rejected)->maybeTrigger();
         $rejected->assertRequestsSent(1);
@@ -224,7 +217,7 @@ class CveRequestTriggerTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_tries_again_once_the_backoff_has_lapsed()
     {
         $rejected = new CveClient(403, '{"error":"feature_disabled","feature":"cve"}');
@@ -239,7 +232,7 @@ class CveRequestTriggerTest extends TestCase
         $retry->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_keeps_retrying_after_a_server_error_rather_than_backing_off()
     {
         // A 5xx is a blip, not an answer, so it must not trip the backoff.
@@ -255,7 +248,7 @@ class CveRequestTriggerTest extends TestCase
         $retry->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_does_nothing_when_there_is_no_lockfile_to_read()
     {
         $this->app['config']['larabug.cve.lock_path'] = '/tmp/larabug-no-such-file.lock';

--- a/tests/CveScanCommandTest.php
+++ b/tests/CveScanCommandTest.php
@@ -4,11 +4,11 @@ namespace LaraBug\Tests;
 
 use LaraBug\Http\Client;
 use LaraBug\Tests\Mocks\CveClient;
+use PHPUnit\Framework\Attributes\Test;
 
 class CveScanCommandTest extends TestCase
 {
-    /** @var string */
-    protected $lockPath;
+    protected string $lockPath;
 
     public function setUp(): void
     {
@@ -42,7 +42,7 @@ class CveScanCommandTest extends TestCase
         return $client;
     }
 
-    /** @test */
+    #[Test]
     public function it_refuses_to_run_while_the_feature_is_disabled()
     {
         $this->app['config']['larabug.cve.enabled'] = false;
@@ -56,7 +56,7 @@ class CveScanCommandTest extends TestCase
         $client->assertRequestsSent(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_reports_a_lockfile_it_cannot_read()
     {
         $this->bindClient(new CveClient());
@@ -66,7 +66,7 @@ class CveScanCommandTest extends TestCase
             ->assertExitCode(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_reports_a_queued_scan_with_its_snapshot_id()
     {
         $this->bindClient(new CveClient(202, '{"queued":true,"snapshot_id":"snap-42"}'));
@@ -77,7 +77,7 @@ class CveScanCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_reports_an_unchanged_lockfile_as_skipped()
     {
         $this->bindClient(new CveClient(200, '{"skipped":"unchanged","snapshot_id":"snap-1"}'));
@@ -87,7 +87,7 @@ class CveScanCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_explains_a_403_as_the_feature_being_off_for_the_project()
     {
         $this->bindClient(new CveClient(403, '{"error":"feature_disabled","feature":"cve"}'));
@@ -97,7 +97,7 @@ class CveScanCommandTest extends TestCase
             ->assertExitCode(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_surfaces_any_other_server_error()
     {
         $this->bindClient(new CveClient(503, 'service unavailable'));
@@ -107,7 +107,7 @@ class CveScanCommandTest extends TestCase
             ->assertExitCode(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_only_includes_dev_packages_when_told_to()
     {
         file_put_contents($this->lockPath, json_encode([

--- a/tests/ExceptionHandlerRegistrationTest.php
+++ b/tests/ExceptionHandlerRegistrationTest.php
@@ -3,8 +3,9 @@
 namespace LaraBug\Tests;
 
 use Exception;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Throwable;
+use PHPUnit\Framework\Attributes\Test;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 
 class ExceptionHandlerRegistrationTest extends TestCase
 {
@@ -12,15 +13,13 @@ class ExceptionHandlerRegistrationTest extends TestCase
     {
         parent::setUp();
 
-        // Laravel only started accepting reportable callbacks in 8.x. Below
-        // that the provider leaves the handler alone and an application keeps
-        // calling handle() itself.
+        // Below Laravel 8 the provider leaves the handler alone and an application calls handle() itself.
         if (! method_exists($this->app[ExceptionHandler::class], 'reportable')) {
             $this->markTestSkipped('The exception handler accepts reportable callbacks from Laravel 8 onwards.');
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_reports_exceptions_through_the_applications_exception_handler()
     {
         $recorder = $this->swapLaraBugForRecorder();
@@ -31,15 +30,14 @@ class ExceptionHandlerRegistrationTest extends TestCase
         $this->assertSame('reported through the handler', $recorder->handled[0]->getMessage());
     }
 
-    /** @test */
+    #[Test]
     public function it_does_not_report_twice_when_the_same_handler_is_resolved_again()
     {
         $recorder = $this->swapLaraBugForRecorder();
 
         $handler = $this->app[ExceptionHandler::class];
 
-        // A wrapping handler, Collision's for one, causes the container to
-        // resolve the same handler a second time.
+        // A wrapping handler, Collision's for one, makes the container resolve the same handler twice.
         $this->app->forgetInstance(ExceptionHandler::class);
         $this->app->bind(ExceptionHandler::class, function () use ($handler) {
             return $handler;
@@ -53,16 +51,14 @@ class ExceptionHandlerRegistrationTest extends TestCase
 
     /**
      * Swap the container binding so reporting records instead of sending.
-     *
-     * @return object
      */
-    protected function swapLaraBugForRecorder()
+    protected function swapLaraBugForRecorder(): object
     {
-        $recorder = new class {
+        $recorder = new class () {
             /** @var array<int, Throwable> */
-            public $handled = [];
+            public array $handled = [];
 
-            public function handle(Throwable $exception, $fileType = 'php', array $customData = [])
+            public function handle(Throwable $exception, $fileType = 'php', array $customData = []): bool
             {
                 $this->handled[] = $exception;
 

--- a/tests/Fakes/LaraBugFakeTest.php
+++ b/tests/Fakes/LaraBugFakeTest.php
@@ -4,6 +4,7 @@ namespace LaraBug\Tests\Fakes;
 
 use LaraBug\Tests\TestCase;
 use LaraBug\Facade as LarabugFacade;
+use PHPUnit\Framework\Attributes\Test;
 
 class LaraBugFakeTest extends TestCase
 {
@@ -18,7 +19,7 @@ class LaraBugFakeTest extends TestCase
         $this->app['config']['larabug.environments'] = ['testing'];
     }
 
-    /** @test */
+    #[Test]
     public function it_will_sent_exception_to_larabug_if_exception_is_thrown()
     {
         $this->app['router']->get('/exception', function () {
@@ -38,13 +39,12 @@ class LaraBugFakeTest extends TestCase
         LarabugFacade::assertNotSent(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_sent_nothing_to_larabug_if_no_exceptions_thrown()
     {
         LarabugFacade::fake();
 
         $this->app['router']->get('/nothing', function () {
-            //
         });
 
         $this->get('/nothing');

--- a/tests/LaraBugTest.php
+++ b/tests/LaraBugTest.php
@@ -8,16 +8,16 @@ use LaraBug\LaraBug;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
+use LaraBug\Http\Client as HttpClient;
 use LaraBug\Tests\Mocks\LaraBugClient;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class LaraBugTest extends TestCase
 {
-    /** @var LaraBug */
-    protected $laraBug;
+    protected LaraBug $laraBug;
 
-    /** @var Mocks\LaraBugClient */
-    protected $client;
+    protected HttpClient $client;
 
     public function setUp(): void
     {
@@ -29,15 +29,14 @@ class LaraBugTest extends TestCase
         ));
     }
 
-    /** @test */
+    #[Test]
     public function is_will_not_crash_if_larabug_returns_error_bad_response_exception()
     {
-        $this->laraBug = new LaraBug($this->client = new \LaraBug\Http\Client(
+        $this->laraBug = new LaraBug($this->client = new HttpClient(
             'login_key',
             'project_key'
         ));
 
-        //
         $this->app['config']['larabug.environments'] = ['testing'];
 
         $this->client->setGuzzleHttpClient(new Client([
@@ -49,15 +48,14 @@ class LaraBugTest extends TestCase
         $this->assertInstanceOf(get_class(new \stdClass()), $this->laraBug->handle(new Exception('is_will_not_crash_if_larabug_returns_error_bad_response_exception')));
     }
 
-    /** @test */
+    #[Test]
     public function is_will_not_crash_if_larabug_returns_normal_exception()
     {
-        $this->laraBug = new LaraBug($this->client = new \LaraBug\Http\Client(
+        $this->laraBug = new LaraBug($this->client = new HttpClient(
             'login_key',
             'project_key'
         ));
 
-        //
         $this->app['config']['larabug.environments'] = ['testing'];
 
         $this->client->setGuzzleHttpClient(new Client([
@@ -69,7 +67,7 @@ class LaraBugTest extends TestCase
         $this->assertFalse($this->laraBug->handle(new Exception('is_will_not_crash_if_larabug_returns_normal_exception')));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_skip_exceptions_based_on_class()
     {
         $this->app['config']['larabug.except'] = [];
@@ -83,7 +81,7 @@ class LaraBugTest extends TestCase
         $this->assertTrue($this->laraBug->isSkipException(NotFoundHttpException::class));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_skip_exceptions_based_on_environment()
     {
         $this->app['config']['larabug.environments'] = [];
@@ -99,7 +97,7 @@ class LaraBugTest extends TestCase
         $this->assertFalse($this->laraBug->isSkipEnvironment());
     }
 
-    /** @test */
+    #[Test]
     public function it_will_return_false_for_sleeping_cache_exception_if_disabled()
     {
         $this->app['config']['larabug.sleep'] = 0;
@@ -107,7 +105,7 @@ class LaraBugTest extends TestCase
         $this->assertFalse($this->laraBug->isSleepingException([]));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_check_if_is_a_sleeping_cache_exception()
     {
         $data = ['host' => 'localhost', 'method' => 'GET', 'exception' => 'it_can_check_if_is_a_sleeping_cache_exception', 'line' => 2, 'file' => '/tmp/Larabug/tests/LaraBugTest.php', 'class' => 'Exception'];
@@ -131,7 +129,7 @@ class LaraBugTest extends TestCase
         $this->assertFalse($this->laraBug->isSleepingException($data));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_formatted_exception_data()
     {
         $data = $this->laraBug->getExceptionData(new Exception(
@@ -144,15 +142,14 @@ class LaraBugTest extends TestCase
         $this->assertSame('http://localhost', $data['fullUrl']);
         $this->assertSame('it_can_get_formatted_exception_data', $data['exception']);
 
-        // The trace the exception was thrown in, so the server can join it to
-        // the request that failed.
+        // trace_id lets the server join the exception to the request that failed.
         $this->assertArrayHasKey('trace_id', $data);
         $this->assertNotSame('', $data['trace_id']);
 
         $this->assertCount(15, $data);
     }
 
-    /** @test */
+    #[Test]
     public function it_collects_a_window_of_source_for_each_frame()
     {
         $data = $this->laraBug->getExceptionData(new Exception(
@@ -162,19 +159,17 @@ class LaraBugTest extends TestCase
         $this->assertIsArray($data['frames']);
         $this->assertNotEmpty($data['frames']);
 
-        // The throw site leads the trace and points at this file.
         $this->assertSame(__FILE__, $data['frames'][0]['file']);
         $this->assertNotEmpty($data['frames'][0]['code']);
 
-        // A code row is the shape executor already uses, and it is a list
-        // rather than a keyed object once encoded.
+        // Code rows must stay a list so they encode as a JSON array, not a keyed object.
         $row = $data['frames'][0]['code'][0];
         $this->assertArrayHasKey('line_number', $row);
         $this->assertArrayHasKey('line', $row);
         $this->assertSame(array_values($data['frames'][0]['code']), $data['frames'][0]['code']);
     }
 
-    /** @test */
+    #[Test]
     public function it_caps_how_many_frames_carry_source()
     {
         $this->app['config']['larabug.max_code_frames'] = 1;
@@ -189,12 +184,11 @@ class LaraBugTest extends TestCase
 
         $this->assertSame(1, $framesWithCode);
 
-        // The deeper frames still name where they were, only the source stops.
         $this->assertGreaterThan(1, count($data['frames']));
         $this->assertNotEmpty($data['frames'][1]['file']);
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_the_data_based_on_the_configuration()
     {
         $this->assertContains('*password*', $this->app['config']['larabug.blacklist']);
@@ -213,15 +207,10 @@ class LaraBugTest extends TestCase
             'Password' => 'testing',
         ];
 
-
         $this->assertContains('***', $this->laraBug->filterVariables($data));
-//        $this->assertArrayHasKey('not_password', $this->laraBug->filterVariables($data));
-//        $this->assertArrayNotHasKey('password', $this->laraBug->filterVariables($data)['not_password2']);
-//        $this->assertArrayNotHasKey('password', $this->laraBug->filterVariables($data)['not_password_3']['nah']);
-//        $this->assertArrayNotHasKey('Password', $this->laraBug->filterVariables($data));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_report_an_exception_to_larabug()
     {
         $this->app['config']['larabug.environments'] = ['testing'];

--- a/tests/LogShippingTest.php
+++ b/tests/LogShippingTest.php
@@ -2,16 +2,16 @@
 
 namespace LaraBug\Tests;
 
-use Illuminate\Support\Facades\Log;
+use RuntimeException;
 use LaraBug\Http\Client;
 use LaraBug\Logger\LogBuffer;
+use Illuminate\Support\Facades\Log;
 use LaraBug\Tests\Mocks\LaraBugClient;
-use RuntimeException;
+use PHPUnit\Framework\Attributes\Test;
 
 class LogShippingTest extends TestCase
 {
-    /** @var LaraBugClient */
-    protected $client;
+    protected LaraBugClient $client;
 
     public function setUp(): void
     {
@@ -22,13 +22,11 @@ class LogShippingTest extends TestCase
 
         $this->app['config']['larabug.project_key'] = 'project';
 
-        // Deliberately no logging.channels.larabug-logs here: the package
-        // defines the channel, and naming it is all an application should have
-        // to do.
+        // Deliberately no logging.channels.larabug-logs config: the package defines the channel, naming it must be enough.
         $this->app['config']['logging.default'] = 'larabug-logs';
     }
 
-    /** @test */
+    #[Test]
     public function it_defines_the_channel_without_any_logging_config()
     {
         $this->assertSame(
@@ -43,7 +41,7 @@ class LogShippingTest extends TestCase
         $this->client->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function an_application_defined_channel_wins()
     {
         $this->app['config']['logging.channels.larabug-logs'] = [
@@ -62,7 +60,7 @@ class LogShippingTest extends TestCase
         $this->assertSame('At the threshold', $logs[0]['message']);
     }
 
-    /** @test */
+    #[Test]
     public function it_ships_log_lines_as_a_batch()
     {
         Log::info('First line');
@@ -84,7 +82,7 @@ class LogShippingTest extends TestCase
         $this->assertSame('error', $payload['logs'][1]['level']);
     }
 
-    /** @test */
+    #[Test]
     public function it_sends_automatically_once_the_batch_is_full()
     {
         $this->app['config']['larabug.logs.batch_size'] = 2;
@@ -95,11 +93,10 @@ class LogShippingTest extends TestCase
         $this->client->assertRequestsSent(1);
     }
 
-    /** @test */
+    #[Test]
     public function it_strips_the_exception_from_the_context()
     {
-        // The Throwable is what LaraBugHandler reports separately, and left in
-        // place it would be the largest thing in the payload.
+        // The Throwable is reported separately by LaraBugHandler and would be the largest thing in the payload.
         Log::error('Something broke', ['exception' => new RuntimeException('boom'), 'order' => 7]);
 
         $this->buffer()->flush();
@@ -110,7 +107,7 @@ class LogShippingTest extends TestCase
         $this->assertSame(7, $context['order']);
     }
 
-    /** @test */
+    #[Test]
     public function it_carries_correlation_ids_from_the_context()
     {
         Log::info('Correlated', ['trace_id' => 'trace-1', 'user_identifier' => 'user-2']);
@@ -123,7 +120,7 @@ class LogShippingTest extends TestCase
         $this->assertSame('user-2', $log['user_identifier']);
     }
 
-    /** @test */
+    #[Test]
     public function it_bounds_what_a_single_context_may_carry()
     {
         $this->app['config']['larabug.logs.max_context_keys'] = 2;
@@ -139,7 +136,7 @@ class LogShippingTest extends TestCase
         $this->assertTrue($context['_truncated']);
     }
 
-    /** @test */
+    #[Test]
     public function it_sends_nothing_once_the_server_refuses_the_batch()
     {
         $this->app['config']['larabug.logs.enabled'] = false;
@@ -151,10 +148,7 @@ class LogShippingTest extends TestCase
         $this->client->assertRequestsSent(0);
     }
 
-    /**
-     * @return LogBuffer
-     */
-    protected function buffer()
+    protected function buffer(): LogBuffer
     {
         return $this->app[LogBuffer::class];
     }

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -2,6 +2,8 @@
 
 namespace LaraBug\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class LoggingTest extends TestCase
 {
     public function setUp(): void
@@ -15,7 +17,7 @@ class LoggingTest extends TestCase
         $this->app['config']['larabug.environments'] = ['testing'];
     }
 
-    /** @test */
+    #[Test]
     public function it_will_not_send_log_information_to_larabug()
     {
         $this->app['router']->get('/log-information-via-route/{type}', function (string $type) {
@@ -34,7 +36,7 @@ class LoggingTest extends TestCase
         \LaraBug\Facade::assertRequestsSent(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_only_send_throwables_to_larabug()
     {
         $this->app['router']->get('/throwables-via-route', function () {

--- a/tests/Mocks/CveClient.php
+++ b/tests/Mocks/CveClient.php
@@ -11,14 +11,11 @@ use PHPUnit\Framework\Assert;
  */
 class CveClient extends \LaraBug\Http\Client
 {
-    /** @var array */
-    public $requests = [];
+    public array $requests = [];
 
-    /** @var int */
-    protected $status;
+    protected int $status;
 
-    /** @var string */
-    protected $body;
+    protected string $body;
 
     public function __construct(int $status = 202, string $body = '{"queued":true,"snapshot_id":"snap-1"}')
     {
@@ -28,20 +25,19 @@ class CveClient extends \LaraBug\Http\Client
         $this->body = $body;
     }
 
-    public function report($exception)
+    public function report($exception): Response
     {
         $this->requests[] = $exception;
 
         return new Response($this->status, [], $this->body);
     }
 
-    public function assertRequestsSent(int $expectedCount)
+    public function assertRequestsSent(int $expectedCount): void
     {
         Assert::assertCount($expectedCount, $this->requests);
     }
 
-    /** @return array|null */
-    public function lastRequest()
+    public function lastRequest(): ?array
     {
         return $this->requests ? end($this->requests) : null;
     }

--- a/tests/Mocks/LaraBugClient.php
+++ b/tests/Mocks/LaraBugClient.php
@@ -7,33 +7,23 @@ use PHPUnit\Framework\Assert;
 
 class LaraBugClient extends \LaraBug\Http\Client
 {
-    const RESPONSE_ID = 'test';
+    public const RESPONSE_ID = 'test';
 
-    /** @var array */
-    protected $requests = [];
+    protected array $requests = [];
 
-    /**
-     * @param array $exception
-     */
-    public function report($exception)
+    public function report($exception): Response
     {
         $this->requests[] = $exception;
 
         return new Response(200, [], json_encode(['id' => self::RESPONSE_ID]));
     }
 
-    /**
-     * @return array
-     */
-    public function requests()
+    public function requests(): array
     {
         return $this->requests;
     }
 
-    /**
-     * @param int $expectedCount
-     */
-    public function assertRequestsSent(int $expectedCount)
+    public function assertRequestsSent(int $expectedCount): void
     {
         Assert::assertCount($expectedCount, $this->requests);
     }

--- a/tests/RequestMonitoringTest.php
+++ b/tests/RequestMonitoringTest.php
@@ -4,17 +4,18 @@ namespace LaraBug\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use LaraBug\Http\Middleware\CaptureRequest;
-use LaraBug\Requests\QueryNormaliser;
-use LaraBug\Requests\RequestBuffer;
-use LaraBug\Requests\RequestListeners;
-use LaraBug\Requests\RequestMonitor;
 use LaraBug\Requests\Sampler;
 use LaraBug\Requests\TraceContext;
+use LaraBug\Requests\RequestBuffer;
+use LaraBug\Requests\RequestMonitor;
+use LaraBug\Requests\QueryNormaliser;
+use LaraBug\Requests\RequestListeners;
+use PHPUnit\Framework\Attributes\Test;
+use LaraBug\Http\Middleware\CaptureRequest;
 
 class RequestMonitoringTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_collapses_in_lists_so_one_query_is_one_group()
     {
         $a = QueryNormaliser::normalise('select * from users where id in (1, 2, 3)');
@@ -27,7 +28,7 @@ class RequestMonitoringTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_collapses_multi_row_inserts()
     {
         $a = QueryNormaliser::normalise('insert into logs (a, b) values (1, 2), (3, 4)');
@@ -36,7 +37,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame($a, $b);
     }
 
-    /** @test */
+    #[Test]
     public function queries_on_different_connections_do_not_group_together()
     {
         $sql = QueryNormaliser::normalise('select * from users');
@@ -47,7 +48,7 @@ class RequestMonitoringTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_never_samples_an_ignored_path()
     {
         config([
@@ -62,7 +63,7 @@ class RequestMonitoringTest extends TestCase
         ));
     }
 
-    /** @test */
+    #[Test]
     public function a_route_learned_after_the_decision_can_still_drop_it()
     {
         config([
@@ -79,7 +80,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertFalse($sampler->reconsider('/admin/reports'));
     }
 
-    /** @test */
+    #[Test]
     public function a_failure_reconsiders_a_request_that_was_not_sampled()
     {
         config([
@@ -93,7 +94,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertTrue($sampler->reconsiderForException());
     }
 
-    /** @test */
+    #[Test]
     public function the_rate_it_reports_is_bounded()
     {
         config(['larabug.requests.sample_rate' => 0]);
@@ -106,7 +107,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(0.25, (new Sampler())->rate());
     }
 
-    /** @test */
+    #[Test]
     public function it_replaces_credential_headers_with_a_marker()
     {
         $request = Request::create('/orders', 'GET');
@@ -118,17 +119,14 @@ class RequestMonitoringTest extends TestCase
 
         $this->assertSame('[redacted]', $headers['authorization']);
         $this->assertSame('[redacted]', $headers['cookie']);
-        // Everything not on the list survives: a header nobody thought about
-        // is usually diagnostic.
+        // Headers not on the list survive: an unanticipated header is usually diagnostic.
         $this->assertSame('application/json', $headers['accept']);
     }
 
-    /** @test */
+    #[Test]
     public function it_redacts_headers_even_when_the_published_config_predates_the_key()
     {
-        // The shape an application upgrading into this feature is actually in.
-        // mergeConfigFrom is shallow, so a published file that predates these
-        // keys replaces the whole requests array and the key is simply absent.
+        // mergeConfigFrom is shallow, so a published config predating these keys replaces the whole requests array.
         $requests = config('larabug.requests');
         unset($requests['redact_headers']);
         config(['larabug.requests' => $requests]);
@@ -139,7 +137,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame('[redacted]', $this->headersFor($request)['authorization']);
     }
 
-    /** @test */
+    #[Test]
     public function a_body_is_kept_only_when_the_request_failed()
     {
         config(['larabug.requests.capture_payload_on_error' => true]);
@@ -148,14 +146,13 @@ class RequestMonitoringTest extends TestCase
 
         $this->assertSame('', $this->payloadFor(Request::create('/orders', 'POST', $body), 200));
         $this->assertSame('', $this->payloadFor(Request::create('/orders', 'POST', $body), 422));
-        // A GET has no body worth keeping, and its parameters are in the query
-        // string, which is never stored.
+        // A GET's parameters live in the query string, which is never stored.
         $this->assertSame('', $this->payloadFor(Request::create('/orders', 'GET', $body), 500));
 
         $this->assertNotSame('', $this->payloadFor(Request::create('/orders', 'POST', $body), 500));
     }
 
-    /** @test */
+    #[Test]
     public function a_kept_body_carries_no_secrets_at_any_depth()
     {
         config(['larabug.requests.capture_payload_on_error' => true]);
@@ -171,18 +168,16 @@ class RequestMonitoringTest extends TestCase
         $payload = json_decode($this->payloadFor($request, 500), true);
 
         $this->assertSame('[redacted]', $payload['password']);
-        // Matched as a substring, because the field that matters is rarely
-        // named exactly what the list says.
+        // Matched as a substring, because the field that matters is rarely named exactly what the list says.
         $this->assertSame('[redacted]', $payload['password_confirmation']);
         // The whole branch goes, because its parent key matched.
         $this->assertSame('[redacted]', $payload['card']);
 
-        // And the rest survives, or there would be nothing left worth storing.
         $this->assertSame('a@b.c', $payload['email']);
         $this->assertSame('SUITE-1001', $payload['order_reference']);
     }
 
-    /** @test */
+    #[Test]
     public function everything_in_one_execution_shares_a_trace_id()
     {
         TraceContext::reset();
@@ -196,7 +191,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertNotSame($first, TraceContext::id());
     }
 
-    /** @test */
+    #[Test]
     public function an_exception_counts_against_the_request_that_threw_it()
     {
         $monitor = new RequestMonitor();
@@ -207,12 +202,11 @@ class RequestMonitoringTest extends TestCase
         $record = $monitor->toArray(Request::create('/orders', 'GET'), new Response('', 500), 1.0);
 
         $this->assertSame(2, $record['exceptions']);
-        // The first id reported wins: it is the one that caused the failure,
-        // and later ones are usually the handler's own noise.
+        // The first id wins: it caused the failure, later ones are usually the handler's own noise.
         $this->assertSame('exc-1', $record['exception_id']);
     }
 
-    /** @test */
+    #[Test]
     public function a_failed_request_that_was_not_sampled_is_kept_at_the_exception_rate()
     {
         config([
@@ -223,7 +217,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertCount(1, $this->recordsForFailedRequest());
     }
 
-    /** @test */
+    #[Test]
     public function a_failed_request_is_dropped_when_the_exception_rate_is_zero()
     {
         config([
@@ -234,7 +228,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertCount(0, $this->recordsForFailedRequest());
     }
 
-    /** @test */
+    #[Test]
     public function a_kept_failure_carries_its_effective_rate_not_the_head_rate()
     {
         config([
@@ -249,7 +243,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(1.0, $records[0]['sample_rate']);
     }
 
-    /** @test */
+    #[Test]
     public function it_records_an_outgoing_call_with_its_query_values_stripped()
     {
         if (! class_exists(\Illuminate\Http\Client\Request::class)) {
@@ -279,7 +273,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame('https://api.example.com/v1/users?token=&page=', $call['url']);
     }
 
-    /** @test */
+    #[Test]
     public function it_marks_an_outgoing_call_that_never_got_a_response()
     {
         if (! class_exists(\Illuminate\Http\Client\Request::class)) {
@@ -299,7 +293,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertNotSame('', $call['error']);
     }
 
-    /** @test */
+    #[Test]
     public function the_outgoing_counter_keeps_counting_past_the_cap()
     {
         config(['larabug.requests.max_outgoing' => 2]);
@@ -315,12 +309,11 @@ class RequestMonitoringTest extends TestCase
 
         $record = $monitor->toArray(Request::create('/orders', 'GET'), new Response('', 200), 1.0);
 
-        // All five counted, only two kept.
         $this->assertSame(5, $record['outgoing_requests']);
         $this->assertCount(2, $record['outgoing']);
     }
 
-    /** @test */
+    #[Test]
     public function it_records_a_message_with_its_recipient_domains_and_not_the_addresses()
     {
         $monitor = new RequestMonitor();
@@ -342,12 +335,11 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(2, $message['to_count']);
         $this->assertSame(1, $message['cc_count']);
         $this->assertSame(0, $message['bcc_count']);
-        // Deduped domains, in recipient order, and never a local part.
         $this->assertSame('example.com,other.test', $message['recipient_domains']);
         $this->assertStringNotContainsString('alice', $message['recipient_domains']);
     }
 
-    /** @test */
+    #[Test]
     public function it_keeps_the_full_recipient_addresses_only_when_they_are_opted_in()
     {
         config(['larabug.requests.capture_mail_recipients' => true]);
@@ -362,7 +354,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame('alice@example.com', $message['recipient_domains']);
     }
 
-    /** @test */
+    #[Test]
     public function it_resolves_the_mailable_class_from_the_call_stack()
     {
         $monitor = new RequestMonitor();
@@ -370,9 +362,8 @@ class RequestMonitoringTest extends TestCase
 
         $event = $this->mailEvent($this->mailMessage('Hi', ['a@b.test']));
 
-        // The resolver walks the stack for a Mailable frame; firing the event
-        // from inside one is what a real send does.
-        $mailable = new class extends \Illuminate\Mail\Mailable {
+        // The resolver walks the stack for a Mailable frame, so fire the event from inside one.
+        $mailable = new class () extends \Illuminate\Mail\Mailable {
             public function fire(RequestListeners $listeners, object $event): void
             {
                 $listeners->onMailSent($event);
@@ -386,7 +377,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(get_class($mailable), $message['mailable']);
     }
 
-    /** @test */
+    #[Test]
     public function mail_sent_without_a_mailable_carries_an_empty_class()
     {
         $monitor = new RequestMonitor();
@@ -397,7 +388,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame('', $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0)['mail'][0]['mailable']);
     }
 
-    /** @test */
+    #[Test]
     public function it_times_a_send_from_its_sending_event()
     {
         $monitor = new RequestMonitor();
@@ -411,12 +402,11 @@ class RequestMonitoringTest extends TestCase
 
         $message = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0)['mail'][0];
 
-        // Paired with its sending event, so a real duration rather than the zero
-        // a sent-only mailer leaves.
+        // Paired with its sending event, so a real duration rather than a sent-only mailer's zero.
         $this->assertGreaterThan(0, $message['duration_ms']);
     }
 
-    /** @test */
+    #[Test]
     public function the_mail_counter_keeps_counting_past_the_cap()
     {
         config(['larabug.requests.max_mail' => 2]);
@@ -432,12 +422,11 @@ class RequestMonitoringTest extends TestCase
 
         $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
 
-        // All five counted, only two kept.
         $this->assertSame(5, $record['mail_sent']);
         $this->assertCount(2, $record['mail']);
     }
 
-    /** @test */
+    #[Test]
     public function it_records_a_notification_with_its_channel_and_notifiable_type()
     {
         $monitor = new RequestMonitor();
@@ -462,7 +451,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(1, $notification['success']);
     }
 
-    /** @test */
+    #[Test]
     public function it_marks_a_failed_notification()
     {
         $monitor = new RequestMonitor();
@@ -479,15 +468,14 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(0, $notification['success']);
     }
 
-    /** @test */
+    #[Test]
     public function a_notification_sent_over_mail_is_not_also_counted_as_mail()
     {
         $monitor = new RequestMonitor();
         $listeners = new RequestListeners($monitor, new Sampler());
 
         $event = $this->mailEvent($this->mailMessage('Reset your password', ['a@b.test']));
-        // The stamp Laravel puts on a notification's mail: the notification path
-        // already records it, so the mail path must leave it alone.
+        // Laravel's stamp on a notification's mail: the notification path records it, the mail path must leave it alone.
         $event->data = ['__laravel_notification' => FakeNotification::class];
 
         $listeners->onMailSent($event);
@@ -498,7 +486,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame([], $record['mail']);
     }
 
-    /** @test */
+    #[Test]
     public function the_notification_counter_keeps_counting_past_the_cap()
     {
         config(['larabug.requests.max_notifications' => 2]);
@@ -514,12 +502,11 @@ class RequestMonitoringTest extends TestCase
 
         $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
 
-        // All five counted, only two kept.
         $this->assertSame(5, $record['notifications_sent']);
         $this->assertCount(2, $record['notifications']);
     }
 
-    /** @test */
+    #[Test]
     public function it_records_cache_operations_with_the_key_narrowed_to_a_prefix()
     {
         $monitor = new RequestMonitor();
@@ -532,7 +519,6 @@ class RequestMonitoringTest extends TestCase
 
         $record = $monitor->toArray(Request::create('/x', 'GET'), new Response('', 200), 1.0);
 
-        // The hit and miss counters still track their totals.
         $this->assertSame(1, $record['cache_hits']);
         $this->assertSame(1, $record['cache_misses']);
 
@@ -540,7 +526,6 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(['hit', 'miss', 'write', 'forget'], array_column($record['cache'], 'op'));
 
         $hit = $record['cache'][0];
-        // The prefix up to the first colon; the id after it is dropped.
         $this->assertSame('user', $hit['key_prefix']);
         $this->assertSame('redis', $hit['store']);
 
@@ -549,7 +534,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(0, $record['cache'][0]['ttl']);
     }
 
-    /** @test */
+    #[Test]
     public function it_keeps_the_full_cache_key_only_when_opted_in()
     {
         config(['larabug.requests.capture_cache_keys' => true]);
@@ -564,7 +549,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame('user:42:profile', $event['key_prefix']);
     }
 
-    /** @test */
+    #[Test]
     public function the_cache_buffer_is_capped()
     {
         config(['larabug.requests.max_cache_events' => 2]);
@@ -593,13 +578,13 @@ class RequestMonitoringTest extends TestCase
         return $event;
     }
 
-    /** @test */
+    #[Test]
     public function it_records_a_queued_mailable_at_dispatch_marked_queued()
     {
         $monitor = new RequestMonitor();
         $listeners = new RequestListeners($monitor, new Sampler());
 
-        $mailable = new class extends \Illuminate\Mail\Mailable {};
+        $mailable = new class () extends \Illuminate\Mail\Mailable {};
         $mailable->to('alice@example.com')->cc('team@other.test');
 
         $event = new \stdClass();
@@ -622,7 +607,7 @@ class RequestMonitoringTest extends TestCase
         $this->assertSame(1, $message['queued']);
     }
 
-    /** @test */
+    #[Test]
     public function a_queued_job_that_is_not_a_mailable_records_no_mail()
     {
         $monitor = new RequestMonitor();
@@ -650,13 +635,9 @@ class RequestMonitoringTest extends TestCase
      */
     private function mailMessage(string $subject, array $to, array $cc = [], array $bcc = []): object
     {
-        $address = fn (string $email): object => new class($email) {
-            /** @var string */
-            private $email;
-
-            public function __construct(string $email)
+        $address = fn (string $email): object => new class ($email) {
+            public function __construct(private string $email)
             {
-                $this->email = $email;
             }
 
             public function getAddress(): string
@@ -665,25 +646,13 @@ class RequestMonitoringTest extends TestCase
             }
         };
 
-        return new class($subject, array_map($address, $to), array_map($address, $cc), array_map($address, $bcc)) {
-            /** @var string */
-            public $subject;
-
-            /** @var array<int, object> */
-            public $to;
-
-            /** @var array<int, object> */
-            public $cc;
-
-            /** @var array<int, object> */
-            public $bcc;
-
-            public function __construct(string $subject, array $to, array $cc, array $bcc)
-            {
-                $this->subject = $subject;
-                $this->to = $to;
-                $this->cc = $cc;
-                $this->bcc = $bcc;
+        return new class ($subject, array_map($address, $to), array_map($address, $cc), array_map($address, $bcc)) {
+            public function __construct(
+                public string $subject,
+                public array $to,
+                public array $cc,
+                public array $bcc,
+            ) {
             }
 
             public function getSubject(): string
@@ -737,10 +706,8 @@ class RequestMonitoringTest extends TestCase
      * A stand-in for an Http client event: the handler reads only ->request and
      * ->response, so a plain object with those is enough and sidesteps the
      * event constructors that changed shape between Laravel versions.
-     *
-     * @param  \Illuminate\Http\Client\Response|null  $response
      */
-    private function outgoingEvent(string $method, string $url, $response): object
+    private function outgoingEvent(string $method, string $url, ?\Illuminate\Http\Client\Response $response): object
     {
         $event = new \stdClass();
         $event->request = new \Illuminate\Http\Client\Request(
@@ -761,12 +728,10 @@ class RequestMonitoringTest extends TestCase
      */
     private function recordsForFailedRequest(): array
     {
-        // A buffer that records rather than sends. It skips the parent
-        // constructor, so no shutdown flush is registered and no client is
-        // needed for a test that only cares whether the record was kept.
-        $buffer = new class extends RequestBuffer {
+        // Skips the parent constructor, so no shutdown flush is registered and no client is needed.
+        $buffer = new class () extends RequestBuffer {
             /** @var array<int, array<string, mixed>> */
-            public $records = [];
+            public array $records = [];
 
             public function __construct()
             {
@@ -794,14 +759,14 @@ class RequestMonitoringTest extends TestCase
     /**
      * @return array<string, string>
      */
-    private function headersFor(Request $request)
+    private function headersFor(Request $request): array
     {
         $record = (new RequestMonitor())->toArray($request, new Response('', 200), 1.0);
 
         return json_decode($record['headers'], true);
     }
 
-    private function payloadFor(Request $request, int $status)
+    private function payloadFor(Request $request, int $status): string
     {
         $record = (new RequestMonitor())->toArray($request, new Response('', $status), 1.0);
 

--- a/tests/ScheduledTaskMonitoringTest.php
+++ b/tests/ScheduledTaskMonitoringTest.php
@@ -4,6 +4,7 @@ namespace LaraBug\Tests;
 
 use LaraBug\Console\CommandBuffer;
 use LaraBug\Console\CommandListeners;
+use PHPUnit\Framework\Attributes\Test;
 use LaraBug\Console\ScheduledTaskBuffer;
 use LaraBug\Console\ScheduledTaskListeners;
 
@@ -11,14 +12,13 @@ class ScheduledTaskMonitoringTest extends TestCase
 {
     protected function tearDown(): void
     {
-        // The in-flight counter is static, so an unbalanced test would leak into
-        // the next one.
+        // The in-flight counter is static, so an unbalanced test would leak into the next one.
         ScheduledTaskListeners::$inFlight = 0;
 
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_records_a_task_that_ran_with_its_expression_and_duration()
     {
         $buffer = $this->taskBuffer();
@@ -38,7 +38,7 @@ class ScheduledTaskMonitoringTest extends TestCase
         $this->assertNotSame('', $record['trace_id']);
     }
 
-    /** @test */
+    #[Test]
     public function it_records_a_failed_task()
     {
         $buffer = $this->taskBuffer();
@@ -52,7 +52,7 @@ class ScheduledTaskMonitoringTest extends TestCase
         $this->assertSame('failed', $buffer->records[0]['status']);
     }
 
-    /** @test */
+    #[Test]
     public function it_records_a_skipped_task()
     {
         $buffer = $this->taskBuffer();
@@ -66,7 +66,7 @@ class ScheduledTaskMonitoringTest extends TestCase
         $this->assertSame(0.0, $record['duration_ms']);
     }
 
-    /** @test */
+    #[Test]
     public function a_command_run_while_a_task_is_in_flight_is_attributed_to_the_schedule()
     {
         $taskBuffer = $this->taskBuffer();
@@ -77,8 +77,7 @@ class ScheduledTaskMonitoringTest extends TestCase
 
         $task = $this->fakeTask('suite:command-ok');
 
-        // The scheduler starts the task, then runs the command in the same
-        // process, then the task finishes.
+        // The scheduler starts the task, runs the command in the same process, then the task finishes.
         $tasks->onScheduledTaskStarting($this->taskEvent($task));
 
         $input = $this->fakeInput();
@@ -87,16 +86,14 @@ class ScheduledTaskMonitoringTest extends TestCase
 
         $tasks->onScheduledTaskFinished($this->taskEvent($task, 0.1));
 
-        // Counted once, against the schedule: no command record, one task record.
         $this->assertCount(0, $commandBuffer->records);
         $this->assertCount(1, $taskBuffer->records);
         $this->assertSame('suite:command-ok', $taskBuffer->records[0]['task']);
     }
 
-    /** @test */
+    #[Test]
     public function a_standalone_command_is_still_recorded()
     {
-        // With no task in flight, the same command is a command as usual.
         $commandBuffer = $this->commandBuffer();
         $commands = new CommandListeners($commandBuffer);
         $input = $this->fakeInput();
@@ -109,9 +106,9 @@ class ScheduledTaskMonitoringTest extends TestCase
 
     private function taskBuffer(): ScheduledTaskBuffer
     {
-        return new class extends ScheduledTaskBuffer {
+        return new class () extends ScheduledTaskBuffer {
             /** @var array<int, array<string, mixed>> */
-            public $records = [];
+            public array $records = [];
 
             public function __construct()
             {
@@ -126,9 +123,9 @@ class ScheduledTaskMonitoringTest extends TestCase
 
     private function commandBuffer(): CommandBuffer
     {
-        return new class extends CommandBuffer {
+        return new class () extends CommandBuffer {
             /** @var array<int, array<string, mixed>> */
-            public $records = [];
+            public array $records = [];
 
             public function __construct()
             {
@@ -143,21 +140,16 @@ class ScheduledTaskMonitoringTest extends TestCase
 
     private function fakeTask(string $summary, string $expression = '* * * * *'): object
     {
-        return new class($summary, $expression) {
-            /** @var string */
-            public $expression;
+        return new class ($summary, $expression) {
+            public string $expression;
 
-            /** @var string */
-            public $description;
+            public string $description;
 
-            /** @var string|null */
-            public $command = null;
+            public ?string $command = null;
 
-            /** @var bool */
-            public $withoutOverlapping = false;
+            public bool $withoutOverlapping = false;
 
-            /** @var string */
-            private $summary;
+            private string $summary;
 
             public function __construct(string $summary, string $expression)
             {
@@ -200,7 +192,7 @@ class ScheduledTaskMonitoringTest extends TestCase
 
     private function fakeInput(): object
     {
-        return new class {
+        return new class () {
             /** @return array<string, mixed> */
             public function getArguments(): array
             {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,11 +7,6 @@ use Illuminate\Foundation\Application;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -19,9 +14,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     /**
      * @param Application $app
-     * @return array
+     * @return array<int, class-string>
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [ServiceProvider::class];
     }

--- a/tests/TestCommandTest.php
+++ b/tests/TestCommandTest.php
@@ -4,10 +4,13 @@ namespace LaraBug\Tests;
 
 use LaraBug\LaraBug;
 use LaraBug\Tests\Mocks\LaraBugClient;
+use PHPUnit\Framework\Attributes\Test;
 
 class TestCommandTest extends TestCase
 {
-    /** @test */
+    protected LaraBugClient $client;
+
+    #[Test]
     public function it_detects_if_the_login_key_is_set()
     {
         $this->app['config']['larabug.login_key'] = '';
@@ -23,7 +26,7 @@ class TestCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_if_the_project_key_is_set()
     {
         $this->app['config']['larabug.project_key'] = '';
@@ -39,7 +42,7 @@ class TestCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_that_its_running_in_the_correct_environment()
     {
         $this->app['config']['app.env'] = 'production';
@@ -56,7 +59,7 @@ class TestCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_that_it_fails_to_send_to_larabug()
     {
         $this->artisan('larabug:test')

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -4,15 +4,14 @@ namespace LaraBug\Tests;
 
 use LaraBug\LaraBug;
 use LaraBug\Tests\Mocks\LaraBugClient;
+use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Foundation\Auth\User as AuthUser;
 
 class UserTest extends TestCase
 {
-    /** @var Mocks\LaraBugClient */
-    protected $client;
+    protected LaraBugClient $client;
 
-    /** @var LaraBug */
-    protected $laraBug;
+    protected LaraBug $laraBug;
 
     public function setUp(): void
     {
@@ -24,7 +23,7 @@ class UserTest extends TestCase
         ));
     }
 
-    /** @test */
+    #[Test]
     public function it_return_custom_user()
     {
         $this->actingAs((new CustomerUser())->forceFill([
@@ -37,7 +36,7 @@ class UserTest extends TestCase
         $this->assertSame(['id' => 1, 'username' => 'username', 'password' => 'password', 'email' => 'email'], $this->laraBug->getUser());
     }
 
-    /** @test */
+    #[Test]
     public function it_return_custom_user_with_to_larabug()
     {
         $this->actingAs((new CustomerUserWithToLarabug())->forceFill([
@@ -50,7 +49,7 @@ class UserTest extends TestCase
         $this->assertSame(['username' => 'username', 'email' => 'email'], $this->laraBug->getUser());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_nothing_for_ghost()
     {
         $this->assertSame(null, $this->laraBug->getUser());


### PR DESCRIPTION
For v4 the package supports the current Laravel line only, and the source is brought up to the Spatie PHP/Laravel guidelines.

**Dependencies + tooling**
- Laravel 11–13 on PHP 8.2–8.4 (was 6–13 on 7.4–8.4). Guzzle ^7.8, Carbon ^3, Testbench ^9–11, PHPUnit ^11.
- CI matrix cut from the eight-version spread and its exclude pile to the three supported releases. PHPUnit 11 schema, cs-fixer ruleset PSR2 → PSR12.

**Source**
- Typed properties and constructor promotion, native return types incl. `void`, short nullable syntax, early returns over nested `else`, `match`/first-class-callables/nullsafe where they simplify.
- Docblocks that only repeated the signature removed; the surviving comments explain why, not what. Net around 600 lines lighter.
- No behaviour or public API changes. The loose event-handler and Monolog signatures the tests drive directly stay loose on purpose.

**Tests**
- `/** @test */` → `#[Test]` attributes, clearing the 107 annotation deprecations the suite emitted. Properties typed, narration removed; names, assertions and coverage unchanged.

All 107 tests pass (263 assertions), zero deprecations/warnings, php-cs-fixer clean.