### PR TITLE
README: house-style punctuation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -50,11 +50,12 @@ That's it. Every unhandled exception, and every failed queue job, now reports to
 
 ## Documentation
 
-Full documentation — configuration, exception capturing, queue and job monitoring, user context, testing, and troubleshooting — lives at **[larabug.com/docs](https://www.larabug.com/docs)**.
+Full documentation (configuration, exception capturing, queue and job monitoring, user context, testing, and troubleshooting) lives at **[larabug.com/docs](https://www.larabug.com/docs)**.
 
 ## Related
 
-- [LaraBug JavaScript SDK](https://github.com/LaraBug/larabug-js) — frontend error tracking for Vanilla JavaScript, React, Vue 3, and Inertia.js.
+- [LaraBug JavaScript SDK](https://github.com/LaraBug/larabug-js). Frontend error tracking for vanilla JavaScript, React, Vue 3, and Inertia.js.
+- [LaraBug Mobile](https://github.com/LaraBug/larabug-mobile). The iOS and Android app.
 
 ## License
 


### PR DESCRIPTION
Drops the em-dashes (house style avoids dashes as punctuation) and adds the mobile app to Related. Part of harmonizing the larabug-* READMEs (Nodux #1263).