### PR TITLE
Ship Laravel Boost guidelines and skills

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,8 @@
+## LaraBug
+
+- LaraBug is this application's error tracking and monitoring service. The `larabug/larabug` package reports exceptions, log lines, queue jobs, scheduled tasks, artisan commands, HTTP requests and `composer.lock` CVE findings to it.
+- Everything the package does is configured in `config/larabug.php` and driven by `LB_*` environment variables. Read that file before changing behaviour: almost every knob is a documented key there, and each one explains what it costs.
+- Exceptions report themselves while `larabug.register_exception_handler` is true. Never also wire LaraBug into the application's own exception handler, that reports every exception twice.
+- Only exceptions, queue jobs and CVE scanning are on by default. Request, command, scheduled task and log reporting are opt-in because each one spends the account's event quota. Do not turn one on unless you were asked to.
+- IMPORTANT: activate the `larabug-development` skill when configuring the package, filtering what it sends, or reporting to LaraBug from application code.
+- IMPORTANT: activate the `larabug-issue-triage` skill when investigating an exception, failing job or vulnerability that LaraBug may already have recorded.

--- a/resources/boost/skills/larabug-development/SKILL.md
+++ b/resources/boost/skills/larabug-development/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: larabug-development
+description: Use when configuring the LaraBug package, controlling what it reports, or sending data to LaraBug from application code. Covers config/larabug.php and the LB_* environment variables, filtering sensitive data, manual exception reporting, per-exception context, queue job tracking, log shipping, CVE scanning, the JavaScript client, and testing with the LaraBug fake.
+metadata:
+  author: LaraBug
+  tags:
+    - error-tracking
+    - monitoring
+    - observability
+    - larabug
+---
+
+# LaraBug Development
+
+## When to use this skill
+
+Use it when working on anything the `larabug/larabug` package does: configuring it, deciding what it reports, filtering what leaves the application, reporting from code, or writing tests around it.
+
+To investigate an error that LaraBug has already recorded, use the `larabug-issue-triage` skill instead.
+
+## Configuration
+
+Everything lives in `config/larabug.php`, published with:
+
+```
+php artisan vendor:publish --provider="LaraBug\ServiceProvider"
+```
+
+Credentials come from either a DSN or a pair of keys. The DSN wins when both are set.
+
+```
+LB_DSN=https://login-key:project-key@www.larabug.com/api/log
+
+# or
+LB_KEY=your-login-key
+LB_PROJECT_KEY=your-project-key
+```
+
+Read the config file before changing behaviour. Every key documents what it does and what it costs, and the answer to "how do I make it report X" is almost always a key that already exists.
+
+### Reporting is scoped to environments
+
+`larabug.environments` defaults to `['production']`. Nothing is sent from any other environment, which is the usual reason a developer reports that "LaraBug is not working" locally. Add the environment deliberately rather than removing the check, and remember an empty array disables reporting everywhere.
+
+### What is on by default
+
+| Feature | Default | Switch |
+|---|---|---|
+| Exceptions | on | `larabug.register_exception_handler` |
+| Queue jobs | on | `LB_TRACK_JOBS` |
+| CVE scanning | on | `LB_CVE_ENABLED` |
+| Logs | off | name the `larabug-logs` channel in your log stack |
+| HTTP requests | off | `LB_TRACK_REQUESTS` |
+| Artisan commands | off | `LB_TRACK_COMMANDS` |
+| Scheduled tasks | off | `LB_TRACK_SCHEDULED_TASKS` |
+| Queue heartbeat | on | `LB_HEARTBEAT`, needs `schedule:run` |
+
+The off-by-default monitors are off because each one spends the account's event quota. Never switch one on unless you were asked to.
+
+## Exceptions
+
+The package registers itself with the exception handler while `larabug.register_exception_handler` is true, so an application does not wire anything up. If you set it to `false` to gain per-exception control, report by hand:
+
+```php
+use LaraBug\Facade as LaraBug;
+
+try {
+    $this->chargeCustomer($order);
+} catch (PaymentFailed $exception) {
+    LaraBug::handle($exception);
+
+    throw $exception;
+}
+```
+
+Never do both. An application that keeps the handler registered and also calls `handle()` reports every exception twice and bills for both.
+
+### Adding context
+
+Context set before an exception is reported travels with it and is cleared per capture:
+
+```php
+use LaraBug\LaraBug;
+
+LaraBug::context(['order_id' => $order->id, 'gateway' => 'mollie']);
+```
+
+### Suppressing noise
+
+- `larabug.except` lists exception classes that are never sent. `NotFoundHttpException` is there by default.
+- `larabug.sleep` (seconds) suppresses a repeat of the same exception, so a hot loop reports once a minute rather than ten thousand times.
+
+### Identifying the user
+
+An authenticated user is attached automatically. A model is sent via `toArray()`, which usually sends more than you want. Implement the interface to choose:
+
+```php
+use LaraBug\Concerns\Larabugable;
+
+class User extends Authenticatable implements Larabugable
+{
+    public function toLarabug(): array
+    {
+        return ['id' => $this->id, 'plan' => $this->plan];
+    }
+}
+```
+
+## Keeping sensitive data out
+
+`larabug.blacklist` holds glob patterns matched against parameter keys, and it already covers passwords, tokens, authorization, card details, names and emails. Add to it rather than replacing it when the application has its own sensitive fields.
+
+Request monitoring has its own, separate controls, and the cautious defaults are deliberate:
+
+- `capture_headers` is on, but `redact_headers` replaces `authorization`, `cookie` and friends with a marker.
+- `capture_payload_on_error` is off, and even when on it only keeps the body of a failed request. `redact_fields` masks keys inside it.
+- `capture_cache_keys` and `capture_mail_recipients` are off. Query strings are never recorded at all, since reset tokens and signed URL signatures live there.
+
+Do not switch these on to make debugging easier without saying out loud what starts being stored.
+
+## Queue jobs
+
+Job tracking is on by default and reports failures at full rate regardless of `jobs.sample_rate`. To opt a specific job in, or to attach tags and metadata:
+
+```php
+use LaraBug\Concerns\Trackable;
+
+class ProcessPayment implements ShouldQueue
+{
+    use Trackable;
+
+    public function larabugTags(): array
+    {
+        return ['billing'];
+    }
+
+    public function larabugMetadata(): array
+    {
+        return ['order_id' => $this->order->id];
+    }
+}
+```
+
+Or track a single dispatch without touching the job class:
+
+```php
+dispatch_tracked(new ProcessPayment($order));
+```
+
+Filter volume with `jobs.only_queues`, `jobs.ignore_queues` and `jobs.ignore_jobs` before reaching for `sample_rate`.
+
+## Logs
+
+The package defines a `larabug-logs` channel. Naming it in the stack is the opt-in:
+
+```
+LOG_STACK=single,larabug-logs
+LB_LOGS_LEVEL=info
+```
+
+Logs run at far higher volume than exceptions and count against the plan, so `debug` from production is rarely what anyone wants. Defining your own channel called `larabug-logs` overrides the package's.
+
+## CVE scanning
+
+Scans `composer.lock` against LaraBug's database and raises findings as issues. Only package names, versions and a hash of the lock file leave the application.
+
+`LB_CVE_ENABLED` alone does not start scanning: the project also has to have CVE scanning enabled in LaraBug. Until it does, the server answers 403 and the client backs off for an hour, so leaving it on is close to free. Triggering is by request piggyback, the scheduler, or both (`LB_CVE_TRIGGER`).
+
+## JavaScript errors
+
+Include the client in a layout to report browser errors to the same project:
+
+```blade
+@larabugJavaScriptClient
+```
+
+## Artisan commands
+
+- `php artisan larabug:test` sends a deliberate exception to verify credentials and connectivity. Reach for this first when reporting appears broken.
+- `php artisan larabug:scan` runs a CVE scan now.
+- `php artisan larabug:heartbeat --show` prints the worker payload instead of sending it.
+
+## Testing
+
+Swap in the fake and assert against it. Never assert by pointing tests at the real API.
+
+```php
+use LaraBug\Facade as LaraBug;
+
+LaraBug::fake();
+
+$this->post('/orders', $payload)->assertStatus(500);
+
+LaraBug::assertSent(PaymentFailed::class);
+```
+
+Available assertions: `assertSent()`, `assertNotSent()`, `assertNothingSent()` and `assertRequestsSent(int $count)`. `assertSent()` and `assertNotSent()` accept an optional callback for asserting against the reported payload.

--- a/resources/boost/skills/larabug-issue-triage/SKILL.md
+++ b/resources/boost/skills/larabug-issue-triage/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: larabug-issue-triage
+description: Use when investigating a production error, exception, JavaScript error, failing queue job or dependency vulnerability that LaraBug may already have recorded, or when the user asks what is breaking, what is erroring, or why something failed in production. Explains how to reach the recorded issue and its stack trace through the LaraBug MCP server rather than guessing from source.
+metadata:
+  author: LaraBug
+  tags:
+    - error-tracking
+    - debugging
+    - triage
+    - larabug
+---
+
+# LaraBug Issue Triage
+
+## When to use this skill
+
+Use it when the question is about something that already went wrong in a running application: "why is checkout failing", "what is erroring in production", "did that deploy break anything", "what vulnerabilities do we have". LaraBug has the exception, its stack trace and the request that caused it. Read that before reasoning from source.
+
+To configure the package or change what it reports, use the `larabug-development` skill instead.
+
+## Reaching the data
+
+This needs the LaraBug MCP server connected. Check for tools named `list_projects`, `list_issues` and `get_issue` before assuming it is absent.
+
+If it is not connected, tell the user to add it once, then continue:
+
+```
+claude mcp add --transport http larabug https://www.larabug.com/mcp
+```
+
+It authorizes over OAuth, so no token needs pasting. Reading needs the `read` scope, and changing an issue needs `write`.
+
+Without the MCP, do not guess at what production is doing. Say the data is not reachable and ask the user to paste the issue, or to connect the server.
+
+## The path through the tools
+
+Work from the account down to the single occurrence. Each step narrows the next.
+
+1. `list_projects` to find the project, or `get_project_summary` when you already know it and want the current shape: what is failing, how much, and how recently.
+2. `list_issues` to see the grouped problems. An issue is the group; the exceptions inside it are the occurrences.
+3. `get_issue` for one issue's detail: how often it fires, when it started, and whether anyone has touched it.
+4. `get_latest_occurrence` for the part that actually resolves the bug, the stack trace and the request context that produced it.
+5. `list_vulnerabilities` for a project's CVE findings, which are recorded as issues too.
+
+Do not stop at `list_issues`. The issue title names the exception class, which is rarely enough to fix anything. `get_latest_occurrence` is where the file, the line and the request live.
+
+## Reading an occurrence
+
+Anchor on the stack frame inside the application rather than the topmost frame, which is usually vendor code. Then read the request context: the route, the method and the user tell you which path reached it, and that is normally what distinguishes the failing case from the working one.
+
+Cross-check what you read against the current source before proposing a fix. An occurrence is a record of the code as it was deployed, and the line numbers drift once the file has been edited.
+
+Sensitive values arrive redacted by design. A masked field is not a bug in the report, and it is not something to work around.
+
+## Changing an issue
+
+`update_issue_status` and `set_issue_note` write to the user's account and need the `write` scope.
+
+Treat them as the user's call. Closing an issue because a fix has been written is a judgement about whether the fix works, so propose it and let the user decide, unless they have already told you to close things as you go. A note recording what you found is the safer of the two and is usually welcome.
+
+## Reporting back
+
+Give the user the issue and the evidence, not a summary of the tool output. What broke, where in the application, what the triggering request had in common, how often it fires and since when. Then the fix.
+
+If several issues share a root cause, say so once rather than walking through each of them.

--- a/tests/BoostResourcesTest.php
+++ b/tests/BoostResourcesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace LaraBug\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Yaml\Yaml;
+
+class BoostResourcesTest extends TestCase
+{
+    #[Test]
+    public function it_ships_a_single_guideline()
+    {
+        $guidelines = glob(self::boostPath('guidelines/*'));
+
+        $this->assertSame(
+            [self::boostPath('guidelines/core.blade.php')],
+            $guidelines,
+            'Boost keeps one guideline per third-party package, so extra files silently overwrite each other.'
+        );
+    }
+
+    #[Test]
+    #[DataProvider('skillDirectories')]
+    public function it_ships_a_skill_boost_can_discover(string $directory, string $path)
+    {
+        $skillFile = $path . '/SKILL.md';
+
+        $this->assertFileExists($skillFile);
+
+        $frontmatter = $this->parseFrontmatter((string) file_get_contents($skillFile));
+
+        $this->assertNotEmpty(
+            $frontmatter['name'] ?? null,
+            'Boost drops a skill whose frontmatter has no name, without reporting it.'
+        );
+
+        $this->assertNotEmpty(
+            $frontmatter['description'] ?? null,
+            'Boost drops a skill whose frontmatter has no description, without reporting it.'
+        );
+
+        $this->assertSame(
+            $directory,
+            $frontmatter['name'],
+            'Boost installs a skill under its frontmatter name rather than its directory name.'
+        );
+    }
+
+    /** @return array<int, array{0: string, 1: string}> */
+    public static function skillDirectories(): array
+    {
+        return array_map(
+            fn (string $path): array => [basename($path), $path],
+            glob(self::boostPath('skills/*'), GLOB_ONLYDIR)
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function parseFrontmatter(string $content): array
+    {
+        if (! preg_match('/^\s*---\s*\n(.*?)\n---\s*\n/s', $content, $matches)) {
+            $this->fail('The skill has no YAML frontmatter block for Boost to read.');
+        }
+
+        $frontmatter = Yaml::parse($matches[1]);
+
+        $this->assertIsArray($frontmatter, 'The skill frontmatter is not a YAML mapping.');
+
+        return $frontmatter;
+    }
+
+    private static function boostPath(string $path): string
+    {
+        return __DIR__ . '/../resources/boost/' . $path;
+    }
+}


### PR DESCRIPTION
Closes #1273 in Nodux.

Boost reads a third-party package's `resources/boost` directory, which is how `spatie/laravel-ray`, `barryvdh/laravel-debugbar` and `filament/filament` reach coding agents. Adding it here makes `larabug/larabug` show up in the host application's `boost.json` the same way, with no changes needed upstream.

One always-loaded guideline, kept short, plus two on-demand skills: `larabug-development` for configuring the package and reporting from code, `larabug-issue-triage` for reading an already recorded issue through the LaraBug MCP server. Two skills rather than one because the trigger descriptions are what decide activation, and those two situations have nothing in common.

Boost silently drops a skill whose frontmatter is missing `name` or `description`, and installs a skill under its frontmatter name rather than its directory name, so the test pins both. Boost also keeps only one guideline per third-party package, so the test pins that there is exactly one.

Verified against Boost 2.4 in larabug-app: the package is discovered as `larabug/larabug (guidelines, skills)`, both skills parse, and the guideline composes into the generated output.

`resources/` is not `export-ignore`d, so this ships in the dist archive.